### PR TITLE
[Refactor] Balance Checking as Form Validations

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_ARWEAVE_HOST=localhost
-NEXT_PUBLIC_ARWEAVE_PORT=1984
-NEXT_PUBLIC_ARWEAVE_PROTOCOL=http
-DATABASE_URL=postgres://postgres:password@localhost:15432/holaplex
+NEXT_PUBLIC_ARWEAVE_HOST=arweave.net
+NEXT_PUBLIC_ARWEAVE_PORT=443
+NEXT_PUBLIC_ARWEAVE_PROTOCOL=https
+sDATABASE_URL=postgres://postgres:password@localhost:15432/holaplex

--- a/pages/storefront/edit.tsx
+++ b/pages/storefront/edit.tsx
@@ -19,10 +19,10 @@ import { WalletContext } from '@/modules/wallet'
 import arweaveSDK from '@/modules/arweave/client'
 import DomainFormItem from '@/common/components/elements/DomainFormItem'
 import InlineFormItem from '@/common/components/elements/InlineFormItem'
-import { isNil, reduce, propEq, findIndex, pipe, identity, merge, update, assocPath, isEmpty, ifElse, has, prop, lensPath, view, when } from 'ramda';
-import HowToArModal from '@/common/components/elements/HowToArModal';
+import HowToArModal from '@/components/elements/HowToArModal'
+import { isNil, reduce, propEq, findIndex, pipe, not, merge, update, assocPath, isEmpty, ifElse, has, prop, lensPath, view, when, gt } from 'ramda';
 
-const { Text, Title, Paragraph } = Typography
+const { Text, Title } = Typography
 
 const PreviewButton = styled.div<{ textColor: string }>`
   height: 52px;
@@ -106,20 +106,16 @@ interface StorefrontEditProps {
   track: GoogleTracker
 }
 
-export default function Edit( { track }: StorefrontEditProps) {
+export default function Edit({ track }: StorefrontEditProps) {
   const [submitting, setSubmitting] = useState(false)
   const router = useRouter()
   const arweave = initArweave()
+  const ar = arweaveSDK.using(arweave)
   const [tab, setTab] = useState("theme")
+  const [showARModal, setShowARModal] = useState(false)
   const { storefront } = useContext(StorefrontContext)
   const [form] = Form.useForm()
-  const {
-    solana,
-    wallet,
-    arweaveRoadblockVisible,
-    arweaveBalance,
-    displayArweaveRoadblock,
-  } = useContext(WalletContext)
+  const { solana, wallet, arweaveWalletAddress } = useContext(WalletContext)
   const [fields, setFields] = useState<FieldData[]>([
     { name: ['subdomain'], value: storefront?.subdomain },
     { name: ['theme', 'backgroundColor'], value: storefront?.theme.backgroundColor },
@@ -133,7 +129,7 @@ export default function Edit( { track }: StorefrontEditProps) {
     { name: ['meta', 'description'], value: storefront?.meta.description }
   ]);
 
-  if (isNil(solana) || isNil(storefront) || isNil(wallet)) {
+  if (isNil(solana) || isNil(storefront) || isNil(wallet) || isNil(arweaveWalletAddress)) {
     return
   }
 
@@ -144,7 +140,7 @@ export default function Edit( { track }: StorefrontEditProps) {
   const domain = `${values.subdomain}.holaplex.com`
 
   const subdomainUniqueness = async (_: any, subdomain: any) => {
-    const search = await arweaveSDK.using(arweave).storefront.find("holaplex:metadata:subdomain", subdomain || "")
+    const search = await ar.storefront.find("holaplex:metadata:subdomain", subdomain || "")
 
     if (isNil(search) || search.pubkey === wallet.pubkey) {
       return Promise.resolve(subdomain)
@@ -153,24 +149,40 @@ export default function Edit( { track }: StorefrontEditProps) {
     return Promise.reject("The subdomain is already in use. Please pick another.")
   }
 
+  const hasArweaveFunds = async (_: any, [file]: any) => {
+    if (isNil(file) || file.url) {
+      return Promise.resolve()
+    }
+
+    if (ar.wallet.canAfford(arweaveWalletAddress, file.size)) {
+      return Promise.resolve()
+    }
+
+    setShowARModal(true)
+
+    return Promise.reject(new Error("Not enough AR funds to cover the upload fee."))
+  }
+
   const onSubmit = async () => {
     try {
       setSubmitting(true)
 
       const { theme, meta, subdomain } = values
-  
+
       // @ts-ignore
       const logo = popFile(theme.logo[0])
       // @ts-ignore
       const favicon = popFile(meta.favicon[0])
-  
+
       const css = stylesheet({ ...theme, logo })
-      if (arweaveBalance === NaN || arweaveBalance <= 0) {
-        displayArweaveRoadblock(true)
-        return
+
+      if (not(ar.wallet.canAfford(arweaveWalletAddress, Buffer.byteLength(css, 'utf8')))) {
+        setSubmitting(false)
+        setShowARModal(true)
+
+        return Promise.reject()
       }
 
-  
       await arweaveSDK.using(arweave).storefront.upsert(
         {
           ...storefront,
@@ -182,9 +194,9 @@ export default function Edit( { track }: StorefrontEditProps) {
       )
 
       toast(() => (<>Your storefront was updated. Visit <a href={`https://${domain}`}>{domain}</a> to view the changes.</>), { autoClose: 60000 })
-      
+
       router.push("/")
-        .then(() => { 
+        .then(() => {
           track('storefront', 'updated')
 
           setSubmitting(false)
@@ -200,7 +212,6 @@ export default function Edit( { track }: StorefrontEditProps) {
   const tabs = {
     theme: (
       <Row justify="space-between">
-        <HowToArModal isModalVisible={arweaveRoadblockVisible} />
         <Col sm={24} md={12} lg={12}>
           <Title level={2}>Style your store.</Title>
           <InlineFormItem
@@ -210,7 +221,8 @@ export default function Edit( { track }: StorefrontEditProps) {
             label="Logo"
             name={["theme", "logo"]}
             rules={[
-              { required: true, message: "Upload a logo." }
+              { required: true, message: "Upload a logo." },
+              { required: true, validator: hasArweaveFunds }
             ]}
           >
             <Upload>
@@ -297,13 +309,14 @@ export default function Edit( { track }: StorefrontEditProps) {
       <>
         <Title level={2}>Change page meta data.</Title>
         <InlineFormItem
-            noBackground
+          noBackground
           labelCol={{ xs: 8 }}
           wrapperCol={{ xs: 16 }}
           label="Favicon"
           name={["meta", "favicon"]}
           rules={[
-            { required: true, message: "Upload a favicon." }
+            { required: true, message: "Upload a favicon." },
+            { required: true, validator: hasArweaveFunds }
           ]}
         >
           <Upload>
@@ -339,6 +352,10 @@ export default function Edit( { track }: StorefrontEditProps) {
   }
   return (
     <Row justify="center" align="middle">
+      <HowToArModal
+        show={showARModal}
+        onCancel={() => setShowARModal(false)}
+      />
       <Col
         xs={21}
         lg={18}
@@ -350,7 +367,7 @@ export default function Edit( { track }: StorefrontEditProps) {
           onTabChange={async (key) => {
             try {
               await form.validateFields()
-            
+
               setTab(key)
             } catch {
             }

--- a/src/common/components/elements/HowToArModal.tsx
+++ b/src/common/components/elements/HowToArModal.tsx
@@ -1,25 +1,28 @@
 import React from 'react';
-import { Modal } from 'antd';
-type Props = {
-  isModalVisible: boolean;
+import { Modal, Typography } from 'antd';
+const { Paragraph } = Typography
+
+type HowToARModalProps = {
+  show: boolean;
+  onCancel: (event: any) => void,
 }
 
 const HowToArModal = (
-  props: Props
-  ) => (
-		<Modal 
-      title=""
-      closable={false}
-      footer={[]}
-      visible={props.isModalVisible as boolean}>
-			<h1> Oh no! You need Arweave tokens!</h1>
-				<p>
-					Arweave (AR) token is available on Binance. 
-					If you are unable to access Binance please reach out to MaxJ on the 
-					<a href="https://discord.gg/uwmpEmPs">
-          &nbsp;Holaplex Discord server. 
-					</a>
-				</p>
-		</Modal>
+  { show, onCancel }: HowToARModalProps
+) => (
+  <Modal
+    title="Oh no! You need Arweave tokens!"
+    closable={true}
+    footer={[]}
+    onCancel={onCancel}
+    visible={show}>
+    <Paragraph>
+      Arweave (AR) token is available on Binance.
+      If you are unable to access Binance please reach out to MaxJ on the
+      <a href="https://discord.gg/uwmpEmPs" target="_blank">
+        &nbsp;Holaplex Discord server.
+      </a>
+    </Paragraph>
+  </Modal>
 );
 export default HowToArModal

--- a/src/common/components/elements/Upload.tsx
+++ b/src/common/components/elements/Upload.tsx
@@ -1,8 +1,7 @@
 import { Upload } from 'antd'
-import React, { Dispatch, SetStateAction, useContext } from 'react'
-import { isNil, set } from 'ramda'
+import React from 'react'
+import { isEmpty, isNil, always, not } from 'ramda'
 import { initArweave } from '@/modules/arweave'
-import { WalletContext } from '@/modules/wallet'
 
 type UploadProps = {
   onChange?: (uploads: any) => any,
@@ -17,20 +16,11 @@ export default function FileUpload({
   value,
   onChange,
 }: UploadProps) {
-  const {
-    arweaveBalance,
-    displayArweaveRoadblock
-  } = useContext(WalletContext)
   const handleInputChange = async (upload: any) => {
     const arweave = initArweave()
     const file = upload.file
 
     if (isNil(file)) {
-      return
-    }
-
-    if (arweaveBalance === NaN || arweaveBalance <= 0) {
-      displayArweaveRoadblock(true)
       return
     }
 
@@ -58,13 +48,12 @@ export default function FileUpload({
     upload.onSuccess(response, file)
   }
 
-
   return (
     <Upload
       customRequest={handleInputChange}
       maxCount={1}
-      onChange={({ fileList }: any) => { 
-        if (isNil(onChange)) { 
+      onChange={({ fileList }: any) => {
+        if (isNil(onChange)) {
           return
         }
 

--- a/src/modules/arweave/index.ts
+++ b/src/modules/arweave/index.ts
@@ -10,7 +10,3 @@ export const initArweave  = () => {
 
   return arweave
 }
-
-export const getBalance = (address: string, arweave: Arweave) => {
-  return arweave.wallets.getBalance(address)
-}

--- a/src/modules/wallet/context.ts
+++ b/src/modules/wallet/context.ts
@@ -15,10 +15,7 @@ export type WalletContextProps = {
   solana?: Solana;
   connect: (params?: any) => any;
   arweaveWallet?: any;
-  arweaveBalance: number;
-  displayArweaveRoadblock: (display: boolean) => void;
-  arweaveRoadblockVisible: boolean;
-
+  arweaveWalletAddress?: string;
 }
 
 export const WalletContext = React.createContext<WalletContextProps>({ verifying: false, initializing: true, connect: () => {}, })


### PR DESCRIPTION
### Changes
- Update AR balance checking to field validations for upload fields and before submitting the css sheet for the storefront to arweave.
- Add wallet scope on internal arweave sdk to check if wallet can afford the upload.

### Notes

Some duplication between edit and new storefronts but will address this in a dedicated pull request.

### Issues

- No path at this time for local arweave since it doesn't track wallets. Just accepts uploads. Will need to bypass the balance checking when using arlocal.