### PR TITLE
Featured Storefront Avatar Background Color

### DIFF
--- a/src/common/components/elements/StorePreview.tsx
+++ b/src/common/components/elements/StorePreview.tsx
@@ -44,6 +44,10 @@ const Metadata = styled(Col)`
   }
 `;
 
+const StyledAvatar = styled(Avatar)`
+  background: #222222;
+`;
+
 type StorePreviewProps = {
   storefront: Storefront;
   metadata: string[];
@@ -55,7 +59,7 @@ export default function StorePreview({ storefront, metadata }: StorePreviewProps
   return (
     <PreviewCard>
       <Card.Meta
-        avatar={<Avatar size="large" src={<Image preview={false} src={storefront.theme.logo.url} />} />}
+        avatar={<StyledAvatar size="large" src={<Image preview={false} src={storefront.theme.logo.url} />} />}
         title={storefront.meta.title}
         description={<a href={`https://${domain}`} rel="nofollow noreferrer" target="_blank">{domain}</a>}
       />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2388118/142955766-172317ea-5599-4c74-9267-6ad3af352efd.png)

Add bg for avatar the same as the card used when logo is transparent.