### PR TITLE
Fix: Add correct collection metadata per Metaplex NFT Standard

### DIFF
--- a/pages/nfts/new.tsx
+++ b/pages/nfts/new.tsx
@@ -59,11 +59,16 @@ export enum MintStatus {
   SUCCESS,
 }
 
+export interface Collection {
+  name: string;
+  family: string;
+}
+
 export interface NFTValue {
   name: string;
   description: string;
   attributes?: NFTAttribute[];
-  collection?: string;
+  collection?: Collection;
   seller_fee_basis_points: number;
   mintStatus?: MintStatus;
 
@@ -167,7 +172,10 @@ export default function BulkUploadWizard() {
         name: v.name,
         description: v.description,
         symbol: '',
-        collection: v.collection,
+        collection: {
+          name: v.collection,
+          family: '',
+        },
         seller_fee_basis_points: v.seller_fee_basis_points,
         image: filePin.uri,
         files: [{ uri: filePin.uri, type: filePin.type }],


### PR DESCRIPTION
Fixes issue #122 

Example NFT with correct metadata: https://solscan.io/token/4MHHq6NnE3gw18X9C8pCkFEyHPzg5oqo2DCDgCrZsnPL?cluster=devnet#metadata