### PR TITLE
Add ability to set both collection name and family

### DIFF
--- a/pages/nfts/new.tsx
+++ b/pages/nfts/new.tsx
@@ -41,7 +41,8 @@ export interface NFTFormValue {
   name: string;
   imageName: string;
   description: string;
-  collection: string;
+  collectionName: string;
+  collectionFamily: string;
   attributes: Array<NFTAttribute>;
   seller_fee_basis_points: number;
   properties: { creators: Array<Creator>; maxSupply: number };
@@ -173,8 +174,8 @@ export default function BulkUploadWizard() {
         description: v.description,
         symbol: '',
         collection: {
-          name: v.collection,
-          family: '',
+          name: v.collectionName,
+          family: v.collectionFamily,
         },
         seller_fee_basis_points: v.seller_fee_basis_points,
         image: filePin.uri,

--- a/src/modules/nfts/components/wizard/InfoScreen.tsx
+++ b/src/modules/nfts/components/wizard/InfoScreen.tsx
@@ -184,11 +184,18 @@ export default function InfoScreen({
             <TextArea placeholder="optional" autoSize={{ minRows: 3, maxRows: 8 }} />
           </Form.Item>
           <Form.Item
-            name={[nftNumber, 'collection']}
-            label="Collection"
-            initialValue={previousNFT ? previousNFT.collection : ''}
+            name={[nftNumber, 'collectionName']}
+            label="Collection Name"
+            initialValue={previousNFT ? previousNFT.collectionName : ''}
           >
-            <Input placeholder="e.g. Stylish Studs (optional)" />
+            <Input placeholder="e.g., Solflare X NFT (optional)" />
+          </Form.Item>
+          <Form.Item
+            name={[nftNumber, 'collectionFamily']}
+            label="Collection Family"
+            initialValue={previousNFT ? previousNFT.collectionFamily : ''}
+          >
+            <Input placeholder="e.g., Solflare (optional)" />
           </Form.Item>
           <Form.Item label="Attributes">
             <Form.List

--- a/src/modules/nfts/components/wizard/Summary.tsx
+++ b/src/modules/nfts/components/wizard/Summary.tsx
@@ -83,7 +83,14 @@ const SummaryItem = ({
       <Title level={4} style={{ marginBottom: 3 }}>
         {value.name}
       </Title>
-      {value.collection && <Paragraph style={{ marginBottom: 18 }}>{value.collection}</Paragraph>}
+      {value.collectionName && (
+        <Paragraph style={{ marginBottom: 5, fontWeight: 'bold' }}>
+          {value.collectionName}
+        </Paragraph>
+      )}
+      {value.collectionFamily && (
+        <Paragraph style={{ marginBottom: 18 }}>{value.collectionFamily}</Paragraph>
+      )}
       <Paragraph
         ellipsis={{ rows: 2, expandable: true, symbol: 'more' }}
         style={{ opacity: '60%', color: '#fff' }}


### PR DESCRIPTION
Adds the ability to set both a collection name and collection family in the non-storefront minting process (from https://holaplex.com/nfts/new).

Tested with and without metadata, and with both single and multi-mints:

https://solscan.io/token/3fikcQcaDDC9zzswgxgQJSMA9P4Rqp2K8wwzHSmnFce3?cluster=devnet#metadata
https://solscan.io/token/J98UZxnvZLFQ2ijZFFEd9fPh32DK5WEvniV7wggeTyJs?cluster=devnet#metadata
https://solscan.io/token/CbTGRB1hxHCpB3pwFWkmThsFyyPZw37tFmfLZBxKkuKi?cluster=devnet#metadata
https://solscan.io/token/9cEPw4Y3ZkfSQY3hwEJEYMfBt3Y3NrWKatN6c7kBSWkF?cluster=devnet#metadata

**UI Screenshots:**

![Screen Shot 2021-12-01 at 8 51 14 PM](https://user-images.githubusercontent.com/58375830/144348919-2a9c95eb-2bf5-4e26-a9b3-0e56d95e6a7d.png)
![Screen Shot 2021-12-01 at 8 51 33 PM](https://user-images.githubusercontent.com/58375830/144348929-27a5affc-6892-4d07-b3e1-87764d29e2a9.png)


