### PR TITLE
Metainfo ->  Store info

### DIFF
--- a/pages/storefront/edit.tsx
+++ b/pages/storefront/edit.tsx
@@ -251,8 +251,8 @@ export default function Edit({ track }: StorefrontEditorProps) {
                 <Input autoFocus suffix=".holaplex.com" />
               </DomainFormItem>
             </TabPane>
-            <TabPane tab="Metadata" key="metadata">
-              <Title level={2}>Change page meta data.</Title>
+            <TabPane tab="Store info" key="metadata">
+              <Title level={2}>Tell us about your store.</Title>
               <Form.Item
                 label="Favicon"
                 name={['meta', 'favicon']}

--- a/src/common/components/elements/AppHeader.tsx
+++ b/src/common/components/elements/AppHeader.tsx
@@ -5,6 +5,8 @@ import { Layout, Space } from 'antd';
 import useWindowDimensions from '@/hooks/useWindowDimensions';
 import SocialLinks from '@/components/elements/SocialLinks';
 import { useRouter } from 'next/router';
+import { WalletContext } from '@/modules/wallet';
+import { useContext } from 'react';
 
 const HeaderTitle = styled.div`
   font-size: 24px;
@@ -34,6 +36,7 @@ const HeaderLinkWrapper = styled.div<{ active: boolean }>`
 export function AppHeader() {
   const windowDimensions = useWindowDimensions();
   const router = useRouter();
+  const { connect } = useContext(WalletContext);
 
   return (
     <StyledHeader>
@@ -48,7 +51,18 @@ export function AppHeader() {
           </Link>
         )}
       </HeaderTitle>
-      <Space size="large">
+      <Space size="large" wrap>
+        {windowDimensions.width >= 778 && (
+          <HeaderLinkWrapper
+            onClick={() => connect()}
+            active={router.pathname == '/storefront/edit'}
+          >
+            <Link href="/storefront/edit" passHref>
+              Edit store
+            </Link>
+          </HeaderLinkWrapper>
+        )}
+
         <HeaderLinkWrapper active={router.pathname == '/nfts/new'}>
           <Link href="/nfts/new" passHref>
             Mint NFTs

--- a/src/common/components/elements/AppHeader.tsx
+++ b/src/common/components/elements/AppHeader.tsx
@@ -51,7 +51,7 @@ export function AppHeader() {
           </Link>
         )}
       </HeaderTitle>
-      <Space size="large" wrap>
+      <Space size="large">
         {windowDimensions.width >= 778 && (
           <HeaderLinkWrapper
             onClick={() => connect()}

--- a/src/common/components/presentational/CommunityFundInfo.tsx
+++ b/src/common/components/presentational/CommunityFundInfo.tsx
@@ -13,109 +13,6 @@ const HolaLink = styled.a`
   -webkit-text-fill-color: transparent;
 `;
 
-const InitialSaleChartSVG = ({ width = 100, height = 100, ...otherSvgProps }: any) => (
-  <svg
-    width={width}
-    height={height}
-    viewBox="0 0 100 100"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    {...otherSvgProps}
-  >
-    <path
-      d="M50 50V0C77.6142 0 100 22.3858 100 50C100 77.6142 77.6142 100 50 100C22.3858 100 0 77.6142 0 50C0 25.9985 17.0546 5.38307 40.6309 0.885637L50 50Z"
-      fill="url(#paint0_linear_573_217)"
-    />
-    <path
-      d="M50 50L40.6309 0.885637C43.7191 0.296526 46.856 0 50 0V50Z"
-      fill="url(#paint1_linear_573_217)"
-    />
-    <defs>
-      <linearGradient
-        id="paint0_linear_573_217"
-        x1="18.0791"
-        y1="1.69492"
-        x2="80.791"
-        y2="87.2881"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#D24089" />
-        <stop offset="1" stopColor="#B92D44" />
-      </linearGradient>
-      <linearGradient
-        id="paint1_linear_573_217"
-        x1="42.3247"
-        y1="0.847458"
-        x2="58.1128"
-        y2="4.88526"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#84DBC8" />
-        <stop offset="1" stopColor="#55AB86" />
-      </linearGradient>
-    </defs>
-  </svg>
-);
-
-const FutureSalesChartSVG = ({ width = 100, height = 100, ...otherSvgProps }: any) => (
-  <svg
-    width={width}
-    height={height}
-    viewBox="0 0 100 100"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    {...otherSvgProps}
-  >
-    <path
-      d="M50 50V0C77.6142 0 100 22.3858 100 50C100 77.6142 77.6142 100 50 100C22.3858 100 0 77.6142 0 50C0 33.9948 7.66222 18.9568 20.6107 9.54915L50 50Z"
-      fill="url(#paint0_linear_484_145)"
-    />
-    <path
-      d="M50.0002 50L20.6109 9.54918C28.893 3.53193 38.8224 0.201866 49.0578 0.00891113L50.0002 50Z"
-      fill="url(#paint1_linear_484_145)"
-    />
-    <path
-      d="M49.9999 50L49.0575 0.00888238C49.3716 0.00296092 49.6858 0 49.9999 0V50Z"
-      fill="url(#paint2_linear_484_145)"
-    />
-    <defs>
-      <linearGradient
-        id="paint0_linear_484_145"
-        x1="26.9097"
-        y1="6.71428"
-        x2="98.4914"
-        y2="63.4831"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0.0989583" stopColor="#841896" />
-        <stop offset="1" stopColor="#4F1364" />
-      </linearGradient>
-      <linearGradient
-        id="paint1_linear_484_145"
-        x1="25.9243"
-        y1="0.856219"
-        x2="58.0225"
-        y2="26.6115"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#D24089" />
-        <stop offset="1" stopColor="#B92D44" />
-      </linearGradient>
-      <linearGradient
-        id="paint2_linear_484_145"
-        x1="49.2279"
-        y1="0.847458"
-        x2="50.9188"
-        y2="0.890956"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#84DBC8" />
-        <stop offset="1" stopColor="#55AB86" />
-      </linearGradient>
-    </defs>
-  </svg>
-);
-
 const PieChartLegendItem = (props: { text: string; children: React.ReactNode }) => (
   <div style={{ display: 'flex', alignItems: 'center' }}>
     <svg
@@ -134,18 +31,19 @@ const PieChartLegendItem = (props: { text: string; children: React.ReactNode }) 
   </div>
 );
 
-export default function FeesModalContent() {
+export default function CommunityFundInfo() {
   return (
     <div>
       <Title style={{ fontSize: 32, color: 'white' }} level={2}>
-        Fees
+        Hola Community Fund
       </Title>
 
       <Content>
         <Paragraph style={{ fontSize: '18px', opacity: 0.6, marginBottom: 75 }}>
-          Holaplex will receive 2% of the royalties on NFTs minted on our platform.
+          The Hola Community Fund will receive 2% of the royalties on NFTs minted on our platform to
+          be contributed back to the community.
           <HolaLink
-            href="https://holaplex.notion.site/Holaplex-s-Revenue-Model-a9969744446041709f6ddfef2b2760f0"
+            href="https://holaplex.notion.site/Hola-Community-Fund-a9969744446041709f6ddfef2b2760f0"
             target="_blank"
             rel="noreferrer"
           >
@@ -269,3 +167,106 @@ export default function FeesModalContent() {
     </div>
   );
 }
+
+const InitialSaleChartSVG = ({ width = 100, height = 100, ...otherSvgProps }: any) => (
+  <svg
+    width={width}
+    height={height}
+    viewBox="0 0 100 100"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...otherSvgProps}
+  >
+    <path
+      d="M50 50V0C77.6142 0 100 22.3858 100 50C100 77.6142 77.6142 100 50 100C22.3858 100 0 77.6142 0 50C0 25.9985 17.0546 5.38307 40.6309 0.885637L50 50Z"
+      fill="url(#paint0_linear_573_217)"
+    />
+    <path
+      d="M50 50L40.6309 0.885637C43.7191 0.296526 46.856 0 50 0V50Z"
+      fill="url(#paint1_linear_573_217)"
+    />
+    <defs>
+      <linearGradient
+        id="paint0_linear_573_217"
+        x1="18.0791"
+        y1="1.69492"
+        x2="80.791"
+        y2="87.2881"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#D24089" />
+        <stop offset="1" stopColor="#B92D44" />
+      </linearGradient>
+      <linearGradient
+        id="paint1_linear_573_217"
+        x1="42.3247"
+        y1="0.847458"
+        x2="58.1128"
+        y2="4.88526"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#84DBC8" />
+        <stop offset="1" stopColor="#55AB86" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+
+const FutureSalesChartSVG = ({ width = 100, height = 100, ...otherSvgProps }: any) => (
+  <svg
+    width={width}
+    height={height}
+    viewBox="0 0 100 100"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...otherSvgProps}
+  >
+    <path
+      d="M50 50V0C77.6142 0 100 22.3858 100 50C100 77.6142 77.6142 100 50 100C22.3858 100 0 77.6142 0 50C0 33.9948 7.66222 18.9568 20.6107 9.54915L50 50Z"
+      fill="url(#paint0_linear_484_145)"
+    />
+    <path
+      d="M50.0002 50L20.6109 9.54918C28.893 3.53193 38.8224 0.201866 49.0578 0.00891113L50.0002 50Z"
+      fill="url(#paint1_linear_484_145)"
+    />
+    <path
+      d="M49.9999 50L49.0575 0.00888238C49.3716 0.00296092 49.6858 0 49.9999 0V50Z"
+      fill="url(#paint2_linear_484_145)"
+    />
+    <defs>
+      <linearGradient
+        id="paint0_linear_484_145"
+        x1="26.9097"
+        y1="6.71428"
+        x2="98.4914"
+        y2="63.4831"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop offset="0.0989583" stopColor="#841896" />
+        <stop offset="1" stopColor="#4F1364" />
+      </linearGradient>
+      <linearGradient
+        id="paint1_linear_484_145"
+        x1="25.9243"
+        y1="0.856219"
+        x2="58.0225"
+        y2="26.6115"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#D24089" />
+        <stop offset="1" stopColor="#B92D44" />
+      </linearGradient>
+      <linearGradient
+        id="paint2_linear_484_145"
+        x1="49.2279"
+        y1="0.847458"
+        x2="50.9188"
+        y2="0.890956"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#84DBC8" />
+        <stop offset="1" stopColor="#55AB86" />
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/src/modules/nfts/components/wizard/RoyaltiesCreators.tsx
+++ b/src/modules/nfts/components/wizard/RoyaltiesCreators.tsx
@@ -12,6 +12,7 @@ import {
   Col,
   Modal,
 } from 'antd';
+import { toast } from 'react-toastify';
 import Paragraph from 'antd/lib/typography/Paragraph';
 import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
@@ -141,13 +142,6 @@ export const StyledClearButton = styled(Button)`
   }
 `;
 
-// TODO: Style notification
-const openNotification = () => {
-  notification.open({
-    message: 'Address copied to clipboard!',
-  });
-};
-
 const StyledPercentageInput = styled(InputNumber)`
   margin: 0 23px 0 auto;
   font-size: 14px;
@@ -250,7 +244,7 @@ const CreatorsRow = ({
           alt="copyToClipboard"
           onClick={() => {
             navigator.clipboard.writeText(creatorAddress);
-            openNotification();
+            toast('Address copied to clipboard!');
           }}
         />
       )}

--- a/src/modules/nfts/components/wizard/RoyaltiesCreators.tsx
+++ b/src/modules/nfts/components/wizard/RoyaltiesCreators.tsx
@@ -23,7 +23,7 @@ import useOnClickOutside from 'use-onclickoutside';
 import clipBoardIcon from '@/common/assets/images/clipboard.svg';
 import { MAX_CREATOR_LIMIT, MintDispatch, NFTFormValue, Creator, FormValues } from 'pages/nfts/new';
 import { NFTPreviewGrid } from '@/common/components/elements/NFTPreviewGrid';
-import FeesModalContent from '@/common/components/presentational/FeesModalContent';
+import CommunityFundInfo from '@/common/components/presentational/CommunityFundInfo';
 import { isNil } from 'ramda';
 
 const ROYALTIES_INPUT_DEFAULT = 1000;
@@ -328,7 +328,7 @@ const CreatorsRow = ({
             padding: '114px 67px 47px 67px',
           }}
         >
-          <FeesModalContent />
+          <CommunityFundInfo />
         </Modal>
       )}
     </StyledCreatorsRow>


### PR DESCRIPTION
Initially just a small PR to change the wording of Metainfo to Store info in the Store creator, but ended up with the following
- the actual change for meta info -> store info
- added an "Edit store" link/button in the header. Tested on multiple resolutions. Approved by Damian.
- Updated the "royalties modal" to CommunityFund modal inline with Alex's changes
- updated the toast design in royalties page in bulk minting to be inline with the rest of the app