### PR TITLE
update banner tooltip & preview aspect ratio

### DIFF
--- a/pages/storefront/edit.tsx
+++ b/pages/storefront/edit.tsx
@@ -148,7 +148,7 @@ export default function Edit({ track }: StorefrontEditorProps) {
                   <Form.Item
                     label="Banner"
                     name={['theme', 'banner']}
-                    tooltip="Sits at the top of your store, 1500px wide and 500px tall works best!"
+                    tooltip="Sits at the top of your store, 1500px wide and 300px tall (5:1 ratio) works best!"
                     rules={[{ required: false, message: 'Upload your Banner.' }]}
                   >
                     <Upload>

--- a/pages/storefront/new.tsx
+++ b/pages/storefront/new.tsx
@@ -142,7 +142,7 @@ export default function New({ track }: StorefrontEditorProps) {
         <Paragraph>Choose a images, colors, and fonts to fit your store’s brand.</Paragraph>
         <Form.Item
           label="Hero Banner"
-          tooltip="Sits at the top of your store, 1500px wide and 500px tall works best!"
+          tooltip="Sits at the top of your store, 1500px wide and 300px tall (5:1 ratio) works best!"
           name={['theme', 'banner']}
           rules={[{ required: false, message: 'Upload a Hero Image' }]}
         >

--- a/src/modules/storefront/editor.tsx
+++ b/src/modules/storefront/editor.tsx
@@ -32,8 +32,13 @@ export const UploadedLogo = styled.img`
   height: 48px;
   width: 48px;
 `;
+
 export const UploadedBanner = styled.img`
   width: 100%;
+  aspect-ratio: 5 / 1;
+  object-fit: cover;
+  object-position: center top;
+  margin-bottom: 1rem;
 `;
 
 export const PreviewLink = styled.div`


### PR DESCRIPTION
updates banner tooltip and also the aspect ratio of the banner in the preview card to match how it'll actually look on the storefront

related to https://github.com/holaplex/metaplex/pull/158

aspect ratio has great browser coverage now: https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio