### PR TITLE
Refactor Approved Subdomains

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,3 @@ NEXT_PUBLIC_IPFS_CDN_HOST=https://ipfs.cache.holaplex.com
 NEXT_PUBLIC_IMAGE_CDN_HOST=https://images.holaplex.com
 DATABASE_URL=postgres://postgres:password@localhost:15432/holaplex
 SOLANA_ENDPOINT=https://api.devnet.solana.com
-

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
 import StorePreview from '@/components/elements/StorePreview';
 import FeaturedStoreSDK, { StorefrontFeature } from '@/modules/storefront/featured';
+import StorefrontsSDK from '@/modules/storefront/client';
 import {
   PageHeader,
   List,
@@ -23,19 +24,14 @@ import {
   always,
   ifElse,
   filter,
-  concat,
   not,
   pipe,
   is,
-  isNil,
   prop,
   descend,
   ascend,
   sortWith,
   equals,
-  map,
-  range,
-  propEq,
 } from 'ramda';
 import Button from '@/components/elements/Button';
 import { WalletContext } from '@/modules/wallet';
@@ -46,23 +42,30 @@ import {
   SkeletonListing,
 } from '@/common/components/elements/ListingPreview';
 import { SelectValue } from 'antd/lib/select';
-import { TrackingAttributes, useAnalytics } from '@/modules/ganalytics/AnalyticsProvider';
+import { useAnalytics } from '@/modules/ganalytics/AnalyticsProvider';
 
 const { Title, Text } = Typography;
 const Option = Select.Option;
 
-const FEATURED_STOREFRONTS_URL = process.env.FEATURED_STOREFRONTS_URL as string;
-const WHICHDAO = process.env.NEXT_PUBLIC_WHICHDAO as string;
-const DAO_LIST_IPFS = process.env.NEXT_PUBLIC_DAO_LIST_IPFS || "https://ipfs.cache.holaplex.com/bafkreidnqervhpcnszmjrj7l44mxh3tgd7pphh5c4jknmnagifsm62uel4";
-
-const DAOStoreFrontList = async () => {
-  if (WHICHDAO) {
-    const response = await fetch(DAO_LIST_IPFS)
-    const json = await response.json()
-    return json[WHICHDAO];
-  }
-  return []
+export enum FilterOptions {
+  All = 'all',
+  Auctions = 'auctions',
+  InstantSale = 'instant_sale',
 }
+
+export enum SortOptions {
+  RecentlyAdded = 'recently_added',
+  EndingSoonest = 'ending_soonest',
+  Expensive = 'expensive',
+  Cheapest = 'cheapest',
+  BidCount = 'bid_count',
+  Trending = 'trending',
+}
+
+const FEATURED_STOREFRONTS_URL = process.env.FEATURED_STOREFRONTS_URL as string;
+
+const DISCOVERY_DEFAULT_FILTER_BY = process.env.NEXT_PUBLIC_DISCOVERY_DEFAULT_FILTER_BY || FilterOptions.Auctions;
+const DISCOVERY_APPROVED_SUBDOMAINS_URL = process.env.DISCOVERY_APPROVED_SUBDOMAINS_URL;
 
 const HeroTitle = styled.h1`
   font-weight: 600;
@@ -231,20 +234,6 @@ const HeroCol = styled(Col)`
     margin: 0 0 0.5rem 0;
   }
 `;
-export enum FilterOptions {
-  All = 'all',
-  Auctions = 'auctions',
-  InstantSale = 'instant_sale',
-}
-
-export enum SortOptions {
-  RecentlyAdded = 'recently_added',
-  EndingSoonest = 'ending_soonest',
-  Expensive = 'expensive',
-  Cheapest = 'cheapest',
-  BidCount = 'bid_count',
-  Trending = 'trending',
-}
 
 const sortOptions: {
   [key in FilterOptions]: {
@@ -306,29 +295,22 @@ const sorts = {
 
 export async function getStaticProps() {
   const featuredStorefronts = await FeaturedStoreSDK.lookup(FEATURED_STOREFRONTS_URL);
-  const selectedDaoSubdomains = await DAOStoreFrontList();
+  const approvedSubdomains = await StorefrontsSDK.getApprovedSubdomains(DISCOVERY_APPROVED_SUBDOMAINS_URL);
 
   return {
     props: {
       featuredStorefronts,
-      selectedDaoSubdomains,
+      approvedSubdomains,
     },
   };
 }
 
 interface HomeProps {
   featuredStorefronts: StorefrontFeature[];
-  selectedDaoSubdomains: String[];
+  approvedSubdomains: string[];
 }
 
-const getDefaultFilter = () => {
-  if (WHICHDAO) {
-    return FilterOptions.All
-  }
-  return FilterOptions.Auctions
-}
-
-export default function Home({ featuredStorefronts, selectedDaoSubdomains }: HomeProps) {
+export default function Home({ featuredStorefronts, approvedSubdomains }: HomeProps) {
   const { connect } = useContext(WalletContext);
   const { track } = useAnalytics();
   const [show, setShow] = useState(16);
@@ -340,7 +322,7 @@ export default function Home({ featuredStorefronts, selectedDaoSubdomains }: Hom
       .map((_, i) => generateListingShell(i))
   );
   const [displayedListings, setDisplayedListings] = useState<Listing[]>([]);
-  const [filterBy, setFilterBy] = useState<FilterOptions>(getDefaultFilter());
+  const [filterBy, setFilterBy] = useState<FilterOptions>(DISCOVERY_DEFAULT_FILTER_BY as FilterOptions);
   const [sortBy, setSortBy] = useState<SortOptions>(SortOptions.Trending);
   const listingsTopRef = useRef<HTMLInputElement>(null);
 
@@ -383,16 +365,12 @@ export default function Home({ featuredStorefronts, selectedDaoSubdomains }: Hom
   // initial fetch and display
   useEffect(() => {
     async function getListings() {
-      const allListings = await IndexerSDK.getListings();
-      let daoFilteredListings = allListings;
+      const allListings = await IndexerSDK.getListings({ approved: approvedSubdomains });
+    
 
-      if (WHICHDAO) {
-        daoFilteredListings = daoFilteredListings.filter(listing => selectedDaoSubdomains.includes(listing.subdomain))
-      }
-
-      setAllListings(daoFilteredListings);
-      setFeaturedListings(daoFilteredListings.slice(0, 5));
-      setDisplayedListings(applyListingFilterAndSort(daoFilteredListings));
+      setAllListings(allListings);
+      setFeaturedListings(allListings.slice(0, 5));
+      setDisplayedListings(applyListingFilterAndSort(allListings));
 
       setLoading(false);
     }

--- a/src/modules/indexer/client.ts
+++ b/src/modules/indexer/client.ts
@@ -1,4 +1,4 @@
-import { compose, filter, sortWith, prop, pipe, descend, not, ascend, contains } from 'ramda';
+import { compose, filter, sortWith, prop, pipe, descend, not, ascend, includes, when, isNil, always } from 'ramda';
 
 const INDEXER_URL = process.env.NEXT_PUBLIC_INDEXER_RPC_URL as string;
 
@@ -49,7 +49,7 @@ export interface Listing {
 }
 
 export const IndexerSDK = {
-  getListings: async (): Promise<Listing[]> => {
+  getListings: async ({ approved }: { approved: string[] | undefined }): Promise<Listing[]> => {
     const res = await fetch(INDEXER_URL, {
       method: 'POST',
       headers: {
@@ -65,14 +65,20 @@ export const IndexerSDK = {
 
     const json = await res.json();
 
-    return sortWith(
-      [
-        //@ts-ignore   
-        ascend(prop('instantSalePrice')),
-        descend(prop('highestBid')),
-        ascend(prop('endsAt'))
-      ],
-      json.result
-    )
+    return compose<any, Listing[]>(
+      sortWith<Listing>(
+        [
+          ascend<any>(prop('instantSalePrice')),
+          descend(prop('highestBid')),
+          ascend(prop('endsAt'))
+        ]
+      ),
+      when<Listing, any>(
+        always(not(isNil(approved))),
+        //@ts-ignore
+        filter(pipe(prop('subdomain'), (subdomain) => includes(subdomain, approved)))
+      )
+    // @ts-ignore
+    )(json.result);
   },
 };

--- a/src/modules/storefront/client.ts
+++ b/src/modules/storefront/client.ts
@@ -1,0 +1,14 @@
+const storefrontSDK = {
+  getApprovedSubdomains: async (url?: string): Promise<string[] | null> => {
+    if (!url) {
+      return null;
+    }
+
+    const response = await fetch(url)
+    const json = await response.json()
+
+    return json;
+  }
+}
+
+export default storefrontSDK;


### PR DESCRIPTION
### Changes
- Switch to a string[] for managing the whitelist.
- Bundle stuff in sdk wrapper.
- Move filter logic for approved subdomains into getListings on the indexerSDK.
- Configure the default filter using env.

```
DISCOVERY_APPROVED_SUBDOMAINS_URL=https://bafkreighpjfnqufpddg4lbdzpltkvirjnhvarcl62myov5zlk5cro4656u.ipfs.dweb.link
NEXT_PUBLIC_DISCOVERY_DEFAULT_FILTER_BY=all
```
_Additional environment variables required to set approved list and default filter by_

![Screen Shot 2022-01-12 at 1 02 11 PM](https://user-images.githubusercontent.com/2388118/149221792-c7d06c3b-861d-42a2-92e5-bd65d3c23980.png)
