### PR TITLE
add retries to metadata signing

### DIFF
--- a/src/modules/metadata-signing.ts
+++ b/src/modules/metadata-signing.ts
@@ -1,2 +1,3 @@
 
-export const signingQueue = "metadata-signging"
+export const signingQueue = "metadata-signging";
+export const RETRY_AFTER = 2000;


### PR DESCRIPTION
Add retry logic to metadata signing.

This is a non-zero downtime deploy at the moment. We have to delete the old queues and configuration. Will take minting offline only for a minute.