### PR TITLE
Rmv footer / Add social links to About / Re-arrange nav links

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 import { ToastContainer } from 'react-toastify';
 import Head from 'next/head';
 import styled from 'styled-components';
-import { Layout, Col, Row } from 'antd';
+import { Layout, Row } from 'antd';
 import { isNil } from 'ramda';
 import Loading from '@/components/elements/Loading';
 import { WalletProvider } from '@/modules/wallet';
@@ -18,7 +18,7 @@ import {
   GA4_ID,
 } from '@/modules/ganalytics/AnalyticsProvider';
 
-const { Header, Content } = Layout;
+const { Content } = Layout;
 
 const AppContent = styled(Content)`
   display: flex;
@@ -26,8 +26,8 @@ const AppContent = styled(Content)`
   justify-content: space-between;
 `;
 
-const AppFooter = styled(Row)`
-  padding: 60px 50px 30px;
+const ContentWrapper = styled.div`
+  padding-bottom: 3rem;
 `;
 
 const AppLayout = styled(Layout)`
@@ -84,7 +84,9 @@ function MyApp({ Component, pageProps }: AppProps) {
                     <AppHeader />
                     <AppContent>
                       <Loading loading={verifying || searching}>
-                        <Component {...pageProps} track={track} />
+                        <ContentWrapper>
+                          <Component {...pageProps} track={track} />
+                        </ContentWrapper>
                       </Loading>
                     </AppContent>
                   </AppLayout>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,9 +11,12 @@ import { isNil } from 'ramda';
 import Loading from '@/components/elements/Loading';
 import { WalletProvider } from '@/modules/wallet';
 import { StorefrontProvider } from '@/modules/storefront';
-import SocialLinks from '@/components/elements/SocialLinks';
 import { AppHeader } from '@/common/components/elements/AppHeader';
-import { AnalyticsProvider, OLD_GOOGLE_ANALYTICS_ID, GA4_ID } from '@/modules/ganalytics/AnalyticsProvider';
+import {
+  AnalyticsProvider,
+  OLD_GOOGLE_ANALYTICS_ID,
+  GA4_ID,
+} from '@/modules/ganalytics/AnalyticsProvider';
 
 const { Header, Content } = Layout;
 
@@ -81,35 +84,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                     <AppHeader />
                     <AppContent>
                       <Loading loading={verifying || searching}>
-                        <>
-                          <Component {...pageProps} track={track} />
-                          <AppFooter justify="center">
-                            <Col span={24}>
-                              <Row>
-                                <Col xs={24} md={8}>
-                                  <a href="mailto:hola@holaplex.com">hola@holaplex.com</a>
-                                </Col>
-                                <Col xs={0} md={8}>
-                                  <Row justify="center">
-                                    Made with &#10084; on &#160;
-                                    <a
-                                      href="https://www.metaplex.com"
-                                      target="_blank"
-                                      rel="noreferrer"
-                                    >
-                                      Metaplex
-                                    </a>
-                                  </Row>
-                                </Col>
-                                <Col xs={0} md={8}>
-                                  <Row justify="end">
-                                    <SocialLinks />
-                                  </Row>
-                                </Col>
-                              </Row>
-                            </Col>
-                          </AppFooter>
-                        </>
+                        <Component {...pageProps} track={track} />
                       </Loading>
                     </AppContent>
                   </AppLayout>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -5,6 +5,7 @@ import sv from '@/constants/styles';
 import RoadmapImage from '@/assets/images/roadmap-v1.svg';
 import investorData from '@/assets/investors/investors-stub';
 import { List, Space, Row, Col, Typography, Card } from 'antd';
+import SocialLinks from '@/common/components/elements/SocialLinks';
 
 const { Title, Paragraph } = Typography;
 
@@ -100,7 +101,7 @@ const StatTitle = styled.h1`
 `;
 
 const BackedBy = styled(Row)`
-  margin: ${sv.sectionPadding * 2}px 0;
+  margin: ${sv.sectionPadding * 2}px 0 ${sv.sectionPadding * 1.5}px;
 `;
 
 const Investors = styled.div`
@@ -127,15 +128,23 @@ const LogoContainer = styled.a`
   position: relative;
 `;
 
+const SocialWrapper = styled.div`
+  margin: 2rem 0 8rem;
+`;
+
 export default function About() {
   return (
     <>
       <Row justify="center">
         <ContentCol xs={22} md={20}>
           <Space direction="vertical" align="center" size="large">
-            <HeroTitle>Our mission is to empower creators and collectors with a suite of tools to create, market, and sell NFTs.</HeroTitle>
+            <HeroTitle>
+              Our mission is to empower creators and collectors with a suite of tools to create,
+              market, and sell NFTs.
+            </HeroTitle>
             <Pitch>
-              Tools that are open source, owned by creators, are permissionless, and governed by the community. 
+              Tools that are open source, owned by creators, are permissionless, and governed by the
+              community.
             </Pitch>
           </Space>
         </ContentCol>
@@ -218,6 +227,14 @@ export default function About() {
           </Investors>
         </ContentCol>
       </BackedBy>
+      <Row justify="center">
+        <ContentCol xs={22} md={20}>
+          <Title level={2}>Get in touch</Title>
+          <SocialWrapper>
+            <SocialLinks />
+          </SocialWrapper>
+        </ContentCol>
+      </Row>
     </>
   );
 }

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -129,7 +129,7 @@ const LogoContainer = styled.a`
 `;
 
 const SocialWrapper = styled.div`
-  margin: 2rem 0 8rem;
+  margin: 2rem 0 4rem;
 `;
 
 export default function About() {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -53,16 +53,18 @@ const Option = Select.Option;
 
 const FEATURED_STOREFRONTS_URL = process.env.FEATURED_STOREFRONTS_URL as string;
 const WHICHDAO = process.env.NEXT_PUBLIC_WHICHDAO as string;
-const DAO_LIST_IPFS = process.env.NEXT_PUBLIC_DAO_LIST_IPFS || "https://ipfs.cache.holaplex.com/bafkreidnqervhpcnszmjrj7l44mxh3tgd7pphh5c4jknmnagifsm62uel4";
+const DAO_LIST_IPFS =
+  process.env.NEXT_PUBLIC_DAO_LIST_IPFS ||
+  'https://ipfs.cache.holaplex.com/bafkreidnqervhpcnszmjrj7l44mxh3tgd7pphh5c4jknmnagifsm62uel4';
 
 const DAOStoreFrontList = async () => {
   if (WHICHDAO) {
-    const response = await fetch(DAO_LIST_IPFS)
-    const json = await response.json()
+    const response = await fetch(DAO_LIST_IPFS);
+    const json = await response.json();
     return json[WHICHDAO];
   }
-  return []
-}
+  return [];
+};
 
 const HeroTitle = styled.h1`
   font-weight: 600;
@@ -323,10 +325,10 @@ interface HomeProps {
 
 const getDefaultFilter = () => {
   if (WHICHDAO) {
-    return FilterOptions.All
+    return FilterOptions.All;
   }
-  return FilterOptions.Auctions
-}
+  return FilterOptions.Auctions;
+};
 
 export default function Home({ featuredStorefronts, selectedDaoSubdomains }: HomeProps) {
   const { connect } = useContext(WalletContext);
@@ -378,8 +380,6 @@ export default function Home({ featuredStorefronts, selectedDaoSubdomains }: Hom
     sortWith(sorts[sortBy])
   );
 
-    
-
   // initial fetch and display
   useEffect(() => {
     async function getListings() {
@@ -387,7 +387,9 @@ export default function Home({ featuredStorefronts, selectedDaoSubdomains }: Hom
       let daoFilteredListings = allListings;
 
       if (WHICHDAO) {
-        daoFilteredListings = daoFilteredListings.filter(listing => selectedDaoSubdomains.includes(listing.subdomain))
+        daoFilteredListings = daoFilteredListings.filter((listing) =>
+          selectedDaoSubdomains.includes(listing.subdomain)
+        );
       }
 
       setAllListings(daoFilteredListings);
@@ -441,22 +443,24 @@ export default function Home({ featuredStorefronts, selectedDaoSubdomains }: Hom
             </HeroCarousel>
           </HeroCol>
         </Section>
-        { !process.env.NEXT_PUBLIC_WHICHDAO && <StorefrontSection>
-          <Col xs={24}>
-            <Title level={3}>Featured Creators</Title>
-            <FeaturedStores
-              grid={{ xs: 1, sm: 2, md: 2, lg: 2, xl: 4, xxl: 4, gutter: 24 }}
-              dataSource={featuredStorefronts.slice(0, 4)}
-              renderItem={(feature) => (
-                // @ts-ignore
-                <List.Item key={feature.storefront.subdomain}>
-                  {/* @ts-ignore */}
-                  <StorePreview {...feature} />
-                </List.Item>
-              )}
-            />
-          </Col>
-        </StorefrontSection> }
+        {!process.env.NEXT_PUBLIC_WHICHDAO && (
+          <StorefrontSection>
+            <Col xs={24}>
+              <Title level={3}>Featured Creators</Title>
+              <FeaturedStores
+                grid={{ xs: 1, sm: 2, md: 2, lg: 2, xl: 4, xxl: 4, gutter: 24 }}
+                dataSource={featuredStorefronts.slice(0, 4)}
+                renderItem={(feature) => (
+                  // @ts-ignore
+                  <List.Item key={feature.storefront.subdomain}>
+                    {/* @ts-ignore */}
+                    <StorePreview {...feature} />
+                  </List.Item>
+                )}
+              />
+            </Col>
+          </StorefrontSection>
+        )}
         <Section>
           <Col xs={24}>
             <div ref={listingsTopRef} />
@@ -551,12 +555,6 @@ export default function Home({ featuredStorefronts, selectedDaoSubdomains }: Hom
               )}
             </Row>
           </Col>
-        </Section>
-        <Section justify="center" align="middle">
-          <Space direction="vertical" align="center">
-            <Title level={3}>Launch your own Solana NFT store today!</Title>
-            <Button onClick={() => connect()}>Create Your Store</Button>
-          </Space>
         </Section>
       </CenteredContentCol>
     </Row>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/common/components/elements/ListingPreview';
 import { SelectValue } from 'antd/lib/select';
 import { TrackingAttributes, useAnalytics } from '@/modules/ganalytics/AnalyticsProvider';
+import SocialLinks from '@/common/components/elements/SocialLinks';
 
 const { Title, Text } = Typography;
 const Option = Select.Option;
@@ -233,6 +234,7 @@ const HeroCol = styled(Col)`
     margin: 0 0 0.5rem 0;
   }
 `;
+
 export enum FilterOptions {
   All = 'all',
   Auctions = 'auctions',
@@ -424,6 +426,9 @@ export default function Home({ featuredStorefronts, selectedDaoSubdomains }: Hom
             <Space direction="horizontal" size="large">
               <Button onClick={() => connect()}>Create Your Store</Button>
             </Space>
+            <div style={{ marginTop: '2.5rem' }}>
+              <SocialLinks />
+            </div>
           </Marketing>
           <HeroCol xs={24} md={8}>
             <Text strong>Featured Listings</Text>

--- a/pages/storefront/edit.tsx
+++ b/pages/storefront/edit.tsx
@@ -45,8 +45,8 @@ import {
 } from 'ramda';
 import React, { useContext, useState } from 'react';
 import { toast } from 'react-toastify';
-const { TabPane } = Tabs;
 
+const { TabPane } = Tabs;
 type TabKey = 'subdomain' | 'theme' | 'meta';
 
 export default function Edit() {

--- a/pages/storefront/edit.tsx
+++ b/pages/storefront/edit.tsx
@@ -150,7 +150,7 @@ export default function Edit() {
                   <Form.Item
                     label="Banner"
                     name={['theme', 'banner']}
-                    tooltip="Sits at the top of your store, 1500px wide and 500px tall works best!"
+                    tooltip="Sits at the top of your store, 1500px wide and 375px tall works best!"
                     rules={[{ required: false, message: 'Upload your Banner.' }]}
                   >
                     <Upload>

--- a/pages/storefront/new.tsx
+++ b/pages/storefront/new.tsx
@@ -144,7 +144,7 @@ export default function New() {
         <Paragraph>Choose a images, colors, and fonts to fit your store’s brand.</Paragraph>
         <Form.Item
           label="Hero Banner"
-          tooltip="Sits at the top of your store, 1500px wide and 500px tall works best!"
+          tooltip="Sits at the top of your store, 375px wide and 500px tall works best!"
           name={['theme', 'banner']}
           rules={[{ required: false, message: 'Upload a Hero Image' }]}
         >

--- a/src/common/components/elements/AppHeader.tsx
+++ b/src/common/components/elements/AppHeader.tsx
@@ -68,11 +68,6 @@ export function AppHeader() {
       </HeaderTitle>
       {!WHICHDAO && (
         <LinkRow size="large">
-          <HeaderLinkWrapper key="about" active={router.pathname == '/about'}>
-            <Link href="/about" passHref>
-              <a>About</a>
-            </Link>
-          </HeaderLinkWrapper>
           <HeaderLinkWrapper key="nft-new" active={router.pathname == '/nfts/new'}>
             <Link href="/nfts/new" passHref>
               <a>Mint&nbsp;NFTs</a>
@@ -87,7 +82,11 @@ export function AppHeader() {
               <a>Edit store</a>
             </Link>
           </HeaderLinkWrapper>
-
+          <HeaderLinkWrapper key="about" active={router.pathname == '/about'}>
+            <Link href="/about" passHref>
+              <a>About</a>
+            </Link>
+          </HeaderLinkWrapper>
           <HeaderLinkWrapper key="faq" active={false}>
             <a
               href="https://holaplex-support.zendesk.com/hc/en-us"

--- a/src/common/components/elements/AppHeader.tsx
+++ b/src/common/components/elements/AppHeader.tsx
@@ -53,11 +53,10 @@ const LinkRow = styled(Space)`
   }
 `;
 
-const WHICHDAO = process.env.NEXT_PUBLIC_WHICHDAO
+const WHICHDAO = process.env.NEXT_PUBLIC_WHICHDAO;
 export function AppHeader() {
   const router = useRouter();
   const { connect } = useContext(WalletContext);
-
 
   return (
     <StyledHeader>
@@ -68,34 +67,40 @@ export function AppHeader() {
           </a>
         </Link>
       </HeaderTitle>
-      { !WHICHDAO && <LinkRow size="large">
-        <HeaderLinkWrapper
-          key="edit"
-          onClick={() => connect()}
-          active={router.pathname == '/storefront/edit'}
-        >
-          <Link href="/storefront/edit" passHref>
-            <a>Edit store</a>
-          </Link>
-        </HeaderLinkWrapper>
+      {!WHICHDAO && (
+        <LinkRow size="large">
+          <HeaderLinkWrapper key="about" active={router.pathname == '/about'}>
+            <Link href="/about" passHref>
+              <a>About</a>
+            </Link>
+          </HeaderLinkWrapper>
+          <HeaderLinkWrapper key="nft-new" active={router.pathname == '/nfts/new'}>
+            <Link href="/nfts/new" passHref>
+              <a>Mint&nbsp;NFTs</a>
+            </Link>
+          </HeaderLinkWrapper>
+          <HeaderLinkWrapper
+            key="edit"
+            onClick={() => connect()}
+            active={router.pathname == '/storefront/edit'}
+          >
+            <Link href="/storefront/edit" passHref>
+              <a>Edit store</a>
+            </Link>
+          </HeaderLinkWrapper>
 
-        <HeaderLinkWrapper key="nft-new" active={router.pathname == '/nfts/new'}>
-          <Link href="/nfts/new" passHref>
-            <a>Mint&nbsp;NFTs</a>
-          </Link>
-        </HeaderLinkWrapper>
-        <HeaderLinkWrapper key="about" active={router.pathname == '/about'}>
-          <Link href="/about" passHref>
-            <a>About</a>
-          </Link>
-        </HeaderLinkWrapper>
-        <HeaderLinkWrapper key="faq" active={false}>
-          <a href="https://holaplex-support.zendesk.com/hc/en-us" target="_blank" rel="noreferrer">
-            FAQ
-          </a>
-        </HeaderLinkWrapper>
-        {/* {windowDimensions.width > 700 && <SocialLinks />} */}
-      </LinkRow> }
+          <HeaderLinkWrapper key="faq" active={false}>
+            <a
+              href="https://holaplex-support.zendesk.com/hc/en-us"
+              target="_blank"
+              rel="noreferrer"
+            >
+              FAQ
+            </a>
+          </HeaderLinkWrapper>
+          {/* {windowDimensions.width > 700 && <SocialLinks />} */}
+        </LinkRow>
+      )}
     </StyledHeader>
   );
 }

--- a/src/common/components/elements/AppHeader.tsx
+++ b/src/common/components/elements/AppHeader.tsx
@@ -2,7 +2,6 @@ import sv from '@/constants/styles';
 import Link from 'next/link';
 import styled from 'styled-components';
 import { Layout, Space } from 'antd';
-import SocialLinks from '@/components/elements/SocialLinks';
 import { useRouter } from 'next/router';
 import { WalletContext } from '@/modules/wallet';
 import { useContext } from 'react';

--- a/src/common/components/elements/SocialLinks.tsx
+++ b/src/common/components/elements/SocialLinks.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 //@ts-ignore
 import FeatherIcon from 'feather-icons-react';
 import DiscordLogo from '@/assets/images/discord-logo.svg';
+import { useAnalytics } from '@/modules/ganalytics/AnalyticsProvider';
 
 const Container = styled.div`
   ${sv.flexRow};
@@ -27,9 +28,24 @@ const SocialLink = styled.a`
 `;
 
 const SocialLinks = () => {
+  const { track } = useAnalytics();
+
+  function trackSocialLink(network: 'Twitter' | 'Github' | 'Discord') {
+    track('Social link Click', {
+      event_category: 'Misc',
+      event_label: network,
+      socialNetwork: network,
+    });
+  }
+
   return (
     <Container>
-      <SocialLink href="https://twitter.com/holaplex" target="_blank" rel="noreferrer">
+      <SocialLink
+        href="https://twitter.com/holaplex"
+        target="_blank"
+        rel="noreferrer"
+        onClick={() => trackSocialLink('Twitter')}
+      >
         <FeatherIcon icon="twitter" />
       </SocialLink>
       {/* <SocialLink
@@ -42,10 +58,20 @@ const SocialLinks = () => {
       <SocialLink href="https://www.instagram.com/holaplex.nft/" target="_blank" rel="noreferrer">
         <FeatherIcon icon="instagram" />
       </SocialLink> */}
-      <SocialLink href="https://github.com/holaplex" target="_blank" rel="noreferrer">
+      <SocialLink
+        href="https://github.com/holaplex"
+        target="_blank"
+        rel="noreferrer"
+        onClick={() => trackSocialLink('Github')}
+      >
         <FeatherIcon icon="github" />
       </SocialLink>
-      <SocialLink href="https://discord.com/invite/TEu7Qx5ux3" target="_blank" rel="noreferrer">
+      <SocialLink
+        href="https://discord.com/invite/TEu7Qx5ux3"
+        target="_blank"
+        rel="noreferrer"
+        onClick={() => trackSocialLink('Discord')}
+      >
         <Image width={24} height={24} src={DiscordLogo} alt="discord" />
       </SocialLink>
     </Container>

--- a/src/common/components/elements/SocialLinks.tsx
+++ b/src/common/components/elements/SocialLinks.tsx
@@ -8,7 +8,7 @@ import DiscordLogo from '@/assets/images/discord-logo.svg';
 
 const Container = styled.div`
   ${sv.flexRow};
-  gap: 2.5rem;
+  gap: 2rem;
   margin-left: 6px;
   flex-wrap: wrap;
 `;
@@ -23,7 +23,7 @@ const SocialLink = styled.a`
     color: ${sv.colors.cta};
     opacity: 1;
   }
-  transform: scale(1.25);
+  transform: scale(1.2);
 `;
 
 const SocialLinks = () => {
@@ -32,7 +32,7 @@ const SocialLinks = () => {
       <SocialLink href="https://twitter.com/holaplex" target="_blank" rel="noreferrer">
         <FeatherIcon icon="twitter" />
       </SocialLink>
-      <SocialLink
+      {/* <SocialLink
         href="https://www.facebook.com/Holaplex-110107494681247/"
         target="_blank"
         rel="noreferrer"
@@ -41,7 +41,7 @@ const SocialLinks = () => {
       </SocialLink>
       <SocialLink href="https://www.instagram.com/holaplex.nft/" target="_blank" rel="noreferrer">
         <FeatherIcon icon="instagram" />
-      </SocialLink>
+      </SocialLink> */}
       <SocialLink href="https://github.com/holaplex" target="_blank" rel="noreferrer">
         <FeatherIcon icon="github" />
       </SocialLink>

--- a/src/common/components/elements/SocialLinks.tsx
+++ b/src/common/components/elements/SocialLinks.tsx
@@ -8,12 +8,14 @@ import DiscordLogo from '@/assets/images/discord-logo.svg';
 
 const Container = styled.div`
   ${sv.flexRow};
+  gap: 2.5rem;
+  margin-left: 6px;
+  flex-wrap: wrap;
 `;
 
 const SocialLink = styled.a`
   display: block;
   ${sv.flexCenter};
-  margin-left: ${sv.grid * 2}px;
   color: ${sv.colors.buttonText};
   opacity: 0.5;
   transition: opacity 0.2s ease;
@@ -21,6 +23,7 @@ const SocialLink = styled.a`
     color: ${sv.colors.cta};
     opacity: 1;
   }
+  transform: scale(1.25);
 `;
 
 const SocialLinks = () => {

--- a/src/modules/ganalytics/AnalyticsProvider.tsx
+++ b/src/modules/ganalytics/AnalyticsProvider.tsx
@@ -34,7 +34,7 @@ interface CustomEventDimensions {
 }
 
 export interface TrackingAttributes extends CustomEventDimensions {
-  event_category: 'Storefront' | 'Discovery' | 'Minter';
+  event_category: 'Storefront' | 'Discovery' | 'Minter' | 'Misc';
   event_label?: string;
   value?: number;
   [key: string]: string | number | boolean | any[] | null | undefined;


### PR DESCRIPTION
## Problem:

- It's annoying to get to the social links in the footer because you have to get past all auctions in the infinite scroll component above.

## Solution:

- Remove footer
- Move social links component to About.

## This PR also:

- Re-arranges topnav links into a more prioritized order.
- Adds compensating bottom padding in absence of the old footer

## This PR does not:

- Create a new look for the "Backed by" section or the social links (other than size / padding)

## Screenshots:

![Screen Shot 2022-01-21 at 9 15 48 AM](https://user-images.githubusercontent.com/58375830/150558987-2d5c6696-9e4b-4b40-83b7-e5005318272e.png)
![Screen Shot 2022-01-21 at 9 23 16 AM](https://user-images.githubusercontent.com/58375830/150558992-93e72fca-3a96-472c-8a63-35d04b6821e5.png)
![Screen Shot 2022-01-21 at 9 32 51 AM](https://user-images.githubusercontent.com/58375830/150559001-3b9eaf87-15b2-48bc-8e63-b2e29b1bf36f.png)

