### PR TITLE
hasWalletTypeSelected should check for loadable wallets as well. 

### DIFF
--- a/src/common/components/elements/AppHeader.tsx
+++ b/src/common/components/elements/AppHeader.tsx
@@ -29,7 +29,7 @@ export function AppHeader({ setShowMintModal, wallet }: Props) {
   const router = useRouter();
   const { connected, wallet: userWallet, connect: connectUserWallet } = useWallet();
   const { connect } = useContext(WalletContext);
-  const hasWalletTypeSelected = userWallet?.readyState === WalletReadyState.Installed;
+  const hasWalletTypeSelected = userWallet?.readyState === WalletReadyState.Installed || userWallet?.readyState === WalletReadyState.Loadable;
   const connectedAndInstalledWallet = hasWalletTypeSelected && connected;
   useEffect(() => {
     if (!hasWalletTypeSelected || connected) return;


### PR DESCRIPTION
@solana-labs/wallet-adpater marks torus-solana wallet (solana.tor.us) as Loadable when the wallet is available (rather than .Installed) 

```
export declare enum WalletReadyState {
    /**
     * User-installable wallets can typically be detected by scanning for an API
     * that they've injected into the global context. If such an API is present,
     * we consider the wallet to have been installed.
     */
    Installed = "Installed",
    NotDetected = "NotDetected",
    /**
     * Loadable wallets are always available to you. Since you can load them at
     * any time, it's meaningless to say that they have been detected.
     */
    Loadable = "Loadable",
    /**
     * If a wallet is not supported on a given platform (eg. server-rendering, or
     * mobile) then it will stay in the `Unsupported` state.
     */
    Unsupported = "Unsupported"
}
``` 

This PR will fix the production site where the profile picture does not show up. 