### PR TITLE
fix: loading states for infinite scroll and reduced to 25

### DIFF
--- a/pages/profiles/[publicKey]/created.tsx
+++ b/pages/profiles/[publicKey]/created.tsx
@@ -13,9 +13,9 @@ import { TripleGrid } from '@/components/icons/TripleGrid';
 import { ProfileDataProvider } from '../../../src/common/context/ProfileData';
 import Head from 'next/head';
 import { showFirstAndLastFour } from '../../../src/modules/utils/string';
-import { ProfileContainer } from '../../../src/common/components/elements/ProfileContainer';
-import TextInput2 from '../../../src/common/components/elements/TextInput2';
-import { NFTGrid } from './nfts';
+import { ProfileContainer } from '@/components/elements/ProfileContainer';
+import TextInput2 from '@/components/elements/TextInput2';
+import { INFINITE_SCROLL_AMOUNT_INCREMENT, NFTGrid } from './nfts';
 import { HOLAPLEX_MARKETPLACE_SUBDOMAIN } from '../../../src/common/constants/marketplace';
 import { Marketplace } from '@holaplex/marketplace-js-sdk';
 import { isEmpty } from 'ramda';
@@ -146,7 +146,7 @@ const CreatedNFTs: NextPage<WalletDependantPageProps> = (props) => {
         <meta property="description" key="description" content="View owned and created NFTs" />
       </Head>
       <ProfileContainer>
-        <div className="mb-4 flex flex-col items-center gap-6 lg:flex-row lg:justify-between lg:gap-4">
+        <div className="sticky top-0 z-30 flex flex-col items-center gap-6 bg-gray-900 py-4 lg:flex-row lg:justify-between lg:gap-4">
           <div className={`flex w-full justify-start gap-4 lg:items-center`}>
             <ListingFilter title={`All`} filterToCheck={ListingFilters.ALL} count={totalCount} />
             <ListingFilter
@@ -182,7 +182,7 @@ const CreatedNFTs: NextPage<WalletDependantPageProps> = (props) => {
           </div>
         </div>
         <NFTGrid
-          hasMore={hasMore}
+          hasMore={hasMore && nftsToShow.length > 99}
           onLoadMore={async (inView) => {
             if (!inView || loading || filteredNfts.length <= 0) {
               return;
@@ -191,7 +191,8 @@ const CreatedNFTs: NextPage<WalletDependantPageProps> = (props) => {
             const { data: newData } = await fetchMore({
               variables: {
                 ...variables,
-                offset: nftsToShow.length + 100,
+                limit: INFINITE_SCROLL_AMOUNT_INCREMENT,
+                offset: nftsToShow.length + INFINITE_SCROLL_AMOUNT_INCREMENT,
               },
               updateQuery: (prev, { fetchMoreResult }) => {
                 if (!fetchMoreResult) return prev;

--- a/pages/profiles/[publicKey]/nfts.tsx
+++ b/pages/profiles/[publicKey]/nfts.tsx
@@ -36,6 +36,7 @@ import UpdateOfferForm from '../../../src/common/components/forms/UpdateOfferFor
 import { Avatar } from '@/common/components/elements/Avatar';
 import { InView } from 'react-intersection-observer';
 import { isEmpty } from 'ramda';
+import { TailSpin } from 'react-loader-spinner';
 
 type OwnedNFT = OwnedNfTsQuery['nfts'][0];
 
@@ -275,43 +276,47 @@ export const NFTGrid: FC<NFTGridProps> = ({
   loading = false,
 }) => {
   return (
-    <div
-      className={cx(
-        'grid grid-cols-1 gap-6',
-        gridView === '1x1'
-          ? 'grid-cols-1 md:grid-cols-2'
-          : gridView === '2x2'
-          ? 'sm:grid-cols-2'
-          : 'md:grid-cols-3'
-      )}
-    >
-      {loading ? (
-        <>
-          <LoadingNFTCard />
-          <LoadingNFTCard />
-          <LoadingNFTCard />
-        </>
-      ) : (
-        <>
-          {nfts.map((nft) => (
-            <NFTCard
-              key={nft.address}
-              nft={nft}
-              refetch={refetch}
-              loading={loading}
-              marketplace={marketplace}
-            />
-          ))}
-          {hasMore && (
-            <div>
-              <InView threshold={0.1} onChange={onLoadMore}>
-                <LoadingNFTCard />
-              </InView>
+    <>
+      <div
+        className={cx(
+          'grid grid-cols-1 gap-6',
+          gridView === '1x1'
+            ? 'grid-cols-1 md:grid-cols-2'
+            : gridView === '2x2'
+            ? 'sm:grid-cols-2'
+            : 'md:grid-cols-3'
+        )}
+      >
+        {loading ? (
+          <>
+            <LoadingNFTCard />
+            <LoadingNFTCard />
+            <LoadingNFTCard />
+          </>
+        ) : (
+          <>
+            {nfts.map((nft) => (
+              <NFTCard
+                key={nft.address}
+                nft={nft}
+                refetch={refetch}
+                loading={loading}
+                marketplace={marketplace}
+              />
+            ))}
+          </>
+        )}
+      </div>
+      {hasMore && (
+        <div>
+          <InView threshold={0.1} onChange={onLoadMore}>
+            <div className={`my-6 flex w-full items-center justify-center font-bold`}>
+              <TailSpin height={50} width={50} color={`grey`} ariaLabel={`loading-nfts`} />
             </div>
-          )}
-        </>
+          </InView>
+        </div>
       )}
-    </div>
+    </>
   );
 };
 
@@ -322,6 +327,8 @@ enum ListingFilters {
   LISTED,
   UNLISTED,
 }
+
+export const INFINITE_SCROLL_AMOUNT_INCREMENT = 25;
 
 const ProfileNFTs: NextPage<WalletDependantPageProps> = (props) => {
   const { publicKey: pk } = props;
@@ -458,7 +465,7 @@ const ProfileNFTs: NextPage<WalletDependantPageProps> = (props) => {
         <meta property="description" key="description" content="View owned and created NFTs" />
       </Head>
       <ProfileContainer>
-        <div className="mb-4 flex flex-col items-center gap-6 lg:flex-row lg:justify-between lg:gap-4">
+        <div className="sticky top-0 z-30 flex flex-col items-center gap-6 bg-gray-900 py-4 lg:flex-row lg:justify-between lg:gap-4">
           <div className={`flex w-full justify-start gap-4 lg:items-center`}>
             <ListingFilter title={`All`} filterToCheck={ListingFilters.ALL} count={totalCount} />
             <ListingFilter
@@ -494,7 +501,7 @@ const ProfileNFTs: NextPage<WalletDependantPageProps> = (props) => {
           </div>
         </div>
         <NFTGrid
-          hasMore={hasMore}
+          hasMore={hasMore && nftsToShow.length > 99}
           onLoadMore={async (inView) => {
             if (!inView || loading || filteredNfts.length <= 0) {
               return;
@@ -503,7 +510,8 @@ const ProfileNFTs: NextPage<WalletDependantPageProps> = (props) => {
             const { data: newData } = await fetchMore({
               variables: {
                 ...variables,
-                offset: nftsToShow.length + 100,
+                limit: INFINITE_SCROLL_AMOUNT_INCREMENT,
+                offset: nftsToShow.length + INFINITE_SCROLL_AMOUNT_INCREMENT,
               },
               updateQuery: (prev, { fetchMoreResult }) => {
                 if (!fetchMoreResult) return prev;

--- a/pages/profiles/[publicKey]/offers.tsx
+++ b/pages/profiles/[publicKey]/offers.tsx
@@ -88,14 +88,14 @@ const OfferPage: NextPage<WalletDependantPageProps> = ({ publicKey, ...props }) 
     return (
       <div
         onClick={() => setFilter(filterToCheck)}
-        className={`flex  flex-row items-center justify-between rounded-lg font-medium ${
+        className={`flex w-28 flex-row items-center justify-center gap-2 rounded-full p-2 font-medium ${
           filter === filterToCheck
             ? `bg-gray-800`
-            : `cursor-pointer bg-gray-900 text-gray-300 hover:bg-gray-800`
-        } p-1`}
+            : `cursor-pointer border border-gray-800 bg-gray-900 text-gray-300 hover:bg-gray-800`
+        }`}
       >
-        <p className={`mb-0 border-r-2 border-gray-300 px-2 text-base`}>{title}</p>
-        <p className={`mb-0 px-2 text-base`}>{count}</p>
+        <p className={`mb-0 first-letter:text-base`}>{title}</p>
+        <p className={`mb-0 text-base`}>{count}</p>
       </div>
     );
   };
@@ -111,14 +111,16 @@ const OfferPage: NextPage<WalletDependantPageProps> = ({ publicKey, ...props }) 
         />
       </Head>
       <ProfileContainer>
-        <div className={`mb-8 mt-6 grid grid-cols-3 gap-6 lg:flex`}>
-          <OfferFilter title={`All`} count={offerCount} filterToCheck={OfferFilters.ALL} />
-          <OfferFilter title={`Made`} count={sentCount} filterToCheck={OfferFilters.MADE} />
-          <OfferFilter
-            title={`Received`}
-            count={receivedCount}
-            filterToCheck={OfferFilters.RECEIVED}
-          />
+        <div className="sticky top-0 z-30 mb-2 flex flex-col items-center gap-6 bg-gray-900 py-4 lg:flex-row lg:justify-between lg:gap-4">
+          <div className={`flex w-full justify-start gap-4 lg:items-center`}>
+            <OfferFilter title={`All`} count={offerCount} filterToCheck={OfferFilters.ALL} />
+            <OfferFilter title={`Made`} count={sentCount} filterToCheck={OfferFilters.MADE} />
+            <OfferFilter
+              title={`Received`}
+              count={receivedCount}
+              filterToCheck={OfferFilters.RECEIVED}
+            />
+          </div>
         </div>
         <div className={`grid grid-cols-1 gap-4`}>
           {(filter === OfferFilters.ALL || filter === OfferFilters.RECEIVED) &&

--- a/src/common/components/elements/ProfileMenu.tsx
+++ b/src/common/components/elements/ProfileMenu.tsx
@@ -56,7 +56,7 @@ export const ProfileMenu: FC = () => {
   ];
 
   return (
-    <div className="mb-6  border-b-2  border-gray-800">
+    <div className="mb-2 border-b-2  border-gray-800">
       <Tab.Group defaultIndex={defaultTabIndex}>
         <Tab.List className="-mb-0.5 flex h-14 w-full justify-between overflow-x-auto no-scrollbar  sm:justify-start ">
           {tabs.map((tab) => (


### PR DESCRIPTION
- updated infinite scroll to only fetch 25 more
- replaced skeleton loading with a loading spinner for fetching more
- removed loading states where they weren't supposed to be showing up (i.e when no items loaded, or no more items to fetch)
- Added sticky header for filters