### PR TITLE
#349: trending auctions section for new homepage

### DIFF
--- a/pages/home-v2-wip.tsx
+++ b/pages/home-v2-wip.tsx
@@ -1,3 +1,4 @@
+import FeaturedAuctionsSection from '@/common/components/home/FeaturedAuctionsSection';
 import FeaturedBuyNowListingsSection from '@/common/components/home/FeaturedBuyNowListingsSection';
 import FeaturedMarketplacesSection from '@/common/components/home/FeaturedMarketplacesSection';
 import FeaturedProfilesSection from '@/common/components/home/FeaturedProfilesSection';
@@ -14,8 +15,9 @@ const Home: FC = () => {
       <HeroSection />
       <div className="container mx-auto w-3/4">
         <FeaturedMarketplacesSection />
-        <FeaturedBuyNowListingsSection/>
+        <FeaturedBuyNowListingsSection />
         <FeaturedProfilesSection />
+        <FeaturedAuctionsSection />
       </div>
       <Footer />
     </div>
@@ -93,9 +95,7 @@ export const HomeSection: FC & HomeSectionSubtypes = ({ children }) => (
 );
 
 const HomeSectionHeader: Header = ({ children }) => (
-  //TODO revert when ready to swap to new homepage
-  <div className="flex justify-between">
-    {/* <div className="mb-4 flex flex-row items-center justify-between border-b border-gray-800 p-2"> */}
+  <div className="mb-4 flex flex-row items-center justify-between border-b border-gray-800 p-2">
     {children}
   </div>
 );

--- a/pages/home-v2-wip.tsx
+++ b/pages/home-v2-wip.tsx
@@ -14,10 +14,10 @@ const Home: FC = () => {
     <div>
       <HeroSection />
       <div className="container mx-auto w-3/4">
-        <FeaturedMarketplacesSection />
         <FeaturedBuyNowListingsSection />
         <FeaturedProfilesSection />
         <FeaturedAuctionsSection />
+        <FeaturedMarketplacesSection />
       </div>
       <Footer />
     </div>

--- a/src/common/components/home/FeaturedAuctionsSection.tsx
+++ b/src/common/components/home/FeaturedAuctionsSection.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState, VFC } from 'react';
+import { HomeSection, HomeSectionCarousel } from 'pages/home-v2-wip';
+import { IndexerSDK, Listing } from '@/modules/indexer';
+import { ListingPreview } from '../elements/ListingPreview';
+import { FilterOptions, SortOptions } from './home.interfaces';
+
+const CAROUSEL_ROWS: number = 1;
+const CAROUSEL_COLS: number = 2;
+const CAROUSEL_PAGES: number = 5;
+
+const WHICHDAO = process.env.NEXT_PUBLIC_WHICHDAO as string;
+const DAO_LIST_IPFS =
+  process.env.NEXT_PUBLIC_DAO_LIST_IPFS ||
+  'https://ipfs.cache.holaplex.com/bafkreidnqervhpcnszmjrj7l44mxh3tgd7pphh5c4jknmnagifsm62uel4';
+
+const FeaturedAuctionsSection: VFC = () => {
+  const [featuredListings, setFeaturedListings] = useState<Listing[]>([]);
+
+  useEffect(() => {
+    getAndPrepListings()
+      .then((listings) => {
+        setFeaturedListings(listings);
+      })
+      .catch((e) => console.log('Unable to load featured auctions', e));
+  }, []);
+
+  return (
+    <HomeSection>
+      <HomeSection.Header>
+        <HomeSection.Title>Trending auctions</HomeSection.Title>
+        {/* //TODO revert once discovery is ready */}
+        {/* <HomeSection.HeaderAction external href="https://holaplex.com">
+          Discover All
+        </HomeSection.HeaderAction> */}
+      </HomeSection.Header>
+      <HomeSection.Body>
+        <HomeSectionCarousel rows={CAROUSEL_ROWS} cols={CAROUSEL_COLS}>
+          {featuredListings.map((listing, i) => (
+            <HomeSectionCarousel.Item key={listing.listingAddress}>
+              <div className="p-2">
+                <ListingPreview key={listing.listingAddress} listing={listing} meta={{
+                  index: i,
+                  list: 'featured-listings',
+                  sortBy: SortOptions.Trending,
+                  filterBy: FilterOptions.Auctions
+                }} />
+              </div>
+            </HomeSectionCarousel.Item>
+          ))}
+        </HomeSectionCarousel>
+      </HomeSection.Body>
+    </HomeSection>
+  );
+};
+
+async function getAndPrepListings(): Promise<Listing[]> {
+  async function DAOStoreFrontList() {
+    if (WHICHDAO) {
+      const response = await fetch(DAO_LIST_IPFS);
+      const json = await response.json();
+      return json[WHICHDAO];
+    }
+    return [];
+  }
+
+  function isAuction(listing: Listing): boolean {
+    return listing.endsAt !== undefined && listing.endsAt !== null && listing.endsAt.trim() !== '';
+  }
+
+  function compareListingsForSort(a: Listing, b: Listing): number {
+    const aBids: number = a.totalUncancelledBids ? a.totalUncancelledBids : 0;
+    const bBids: number = b.totalUncancelledBids ? b.totalUncancelledBids : 0;
+    if (aBids != bBids) {
+      // primarily sort by most bids first
+      return bBids - aBids;
+    } else {
+      // secondarily sort by ending soonest
+      const aEnd: number = a.endsAt ? Date.parse(a.endsAt) : Number.MAX_SAFE_INTEGER;
+      const bEnd: number = b.endsAt ? Date.parse(b.endsAt) : Number.MAX_SAFE_INTEGER;
+      return aEnd - bEnd;
+    }
+  }
+
+  function applyListingFilterAndSort(listings: Listing[]): Listing[] {
+    const result: Listing[] = listings.filter(isAuction);
+    result.sort(compareListingsForSort);
+    return result;
+  }
+
+  const selectedDaoSubdomains = await DAOStoreFrontList();
+  const allListings = await IndexerSDK.getListings();
+  let daoFilteredListings = allListings;
+
+  if (WHICHDAO) {
+    daoFilteredListings = daoFilteredListings.filter((listing) =>
+      selectedDaoSubdomains.includes(listing.subdomain)
+    );
+  }
+
+  const totalListings: number = CAROUSEL_COLS * CAROUSEL_ROWS * CAROUSEL_PAGES;
+  return applyListingFilterAndSort(daoFilteredListings).slice(0, totalListings);
+}
+
+export default FeaturedAuctionsSection;

--- a/src/common/components/home/FeaturedAuctionsSection.tsx
+++ b/src/common/components/home/FeaturedAuctionsSection.tsx
@@ -53,6 +53,9 @@ const FeaturedAuctionsSection: VFC = () => {
   );
 };
 
+
+// TODO: this was adapted from the v1 homepage and should probably be replaced with
+//  a graph-ql version at some point
 async function getAndPrepListings(): Promise<Listing[]> {
   async function DAOStoreFrontList() {
     if (WHICHDAO) {

--- a/src/common/components/home/FeaturedBuyNowListingsSection.tsx
+++ b/src/common/components/home/FeaturedBuyNowListingsSection.tsx
@@ -47,7 +47,7 @@ const FeaturedBuyNowListingsSection: VFC = () => {
   return (
     <HomeSection>
       <HomeSection.Header>
-        <HomeSection.Title>What&apos;s Hot</HomeSection.Title>
+        <HomeSection.Title>What&apos;s hot</HomeSection.Title>
         {/* //TODO revert once discovery is ready */}
         {/* <HomeSection.HeaderAction external href="https://holaplex.com">
           Discover All

--- a/src/common/components/home/FeaturedProfilesSection.tsx
+++ b/src/common/components/home/FeaturedProfilesSection.tsx
@@ -55,7 +55,7 @@ const FeaturedProfilesSection: VFC = () => {
   return (
     <HomeSection>
       <HomeSection.Header>
-        <HomeSection.Title>Profiles to Follow</HomeSection.Title>
+        <HomeSection.Title>Profiles to follow</HomeSection.Title>
         {/* //TODO revert once discovery is ready  */}
         {/* <HomeSection.HeaderAction external href="https://google.com">
           Discover All


### PR DESCRIPTION
This PR adds the featured auctions section for the v2 homepage.

# Desktop
![image](https://user-images.githubusercontent.com/1540936/169357562-a6da120e-ff70-4cc9-ab2f-65b0c4193ee6.png)

# Mobile
![image](https://user-images.githubusercontent.com/1540936/169357666-4dc72d0f-676d-47eb-ab28-1e84ae6f7c6a.png)

Start in `home-v2-wip.tsx`

# Changes
- reused the v1 listings functionality to add a trending auctions section (`FeaturedAuctionsSection.tsx`, `home-v2-wip.tsx`)
- change the site title to start with `Holaplex` instead of `Tools`

closes #349 