### PR TITLE
#446: use whoToFollow query for alpha

### DIFF
--- a/pages/alpha/index.tsx
+++ b/pages/alpha/index.tsx
@@ -43,7 +43,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
 const AlphaPage = ({ address }: { address: string }) => {
   const anchorWallet = useAnchorWallet();
-  const { connection } = useConnection();
   const {
     connecting,
   } = useWallet();
@@ -70,7 +69,7 @@ const AlphaPage = ({ address }: { address: string }) => {
       },
     });
 
-  const {data: whoToFollowData, loading: loadingWhoToFollow} = useWhoToFollowQuery({variables: {wallet: anchorWallet?.publicKey, limit: 25}});
+  const {data: whoToFollowData} = useWhoToFollowQuery({variables: {wallet: anchorWallet?.publicKey, limit: 25}});
   const profilesToFollow: User[] = (whoToFollowData?.followWallets || []).map(u => ({address: u.address, profile: {handle: u.profile?.handle, profileImageUrl: u.profile?.profileImageUrlLowres}}));
 
   // API is returning duplicates for some reason

--- a/pages/alpha/index.tsx
+++ b/pages/alpha/index.tsx
@@ -4,15 +4,14 @@ import { GetServerSideProps } from 'next';
 import { useAnchorWallet, useConnection, useWallet } from '@solana/wallet-adapter-react';
 import {
   FeedQuery,
-  useAllConnectionsFromQuery,
   useAllConnectionsFromLazyQuery,
   useFeedLazyQuery,
+  useWhoToFollowQuery,
 } from 'src/graphql/indexerTypes';
 import {
   FeedCard,
   LoadingFeedCard,
   LoadingFeedItem,
-  ProfilePFP,
 } from '@/common/components/feed/FeedCard';
 import { InView } from 'react-intersection-observer';
 import {
@@ -21,6 +20,7 @@ import {
   FeedQueryEvent,
   generateFeedCardAttributes,
   shouldAggregate,
+  User,
 } from '@/common/components/feed/feed.utils';
 
 import Footer, { SmallFooter } from '@/common/components/home/Footer';
@@ -29,7 +29,6 @@ import WhoToFollowList from '@/common/components/feed/WhoToFollowList';
 import classNames from 'classnames';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import { Button5 } from '@/common/components/elements/Button2';
-import Link from 'next/link';
 import EmptyFeedCTA from '@/common/components/feed/EmptyFeedCTA';
 
 const INFINITE_SCROLL_AMOUNT_INCREMENT = 25;
@@ -46,12 +45,7 @@ const AlphaPage = ({ address }: { address: string }) => {
   const anchorWallet = useAnchorWallet();
   const { connection } = useConnection();
   const {
-    connected,
-    wallet: userWallet,
-    connect: connectUserWallet,
-    publicKey,
     connecting,
-    disconnecting,
   } = useWallet();
 
   const myPubkey = address ?? anchorWallet?.publicKey.toBase58() ?? null;
@@ -69,24 +63,20 @@ const AlphaPage = ({ address }: { address: string }) => {
   const feedEvents = data?.feedEvents ?? [];
 
   // Switching to this as soon as we get it to auoto refetch on new follows
-  const [connectionQuery, { data: myConnectionsFromData, refetch }] =
+  const [connectionQuery, { data: myConnectionsFromData }] =
     useAllConnectionsFromLazyQuery({
       variables: {
         from: anchorWallet?.publicKey.toBase58() || myPubkey,
       },
     });
 
+  const {data: whoToFollowData, loading: loadingWhoToFollow} = useWhoToFollowQuery({variables: {wallet: anchorWallet?.publicKey, limit: 25}});
+  const profilesToFollow: User[] = (whoToFollowData?.followWallets || []).map(u => ({address: u.address, profile: {handle: u.profile?.handle, profileImageUrl: u.profile?.profileImageUrlLowres}}));
+
   // API is returning duplicates for some reason
   const myFollowingList: string[] | undefined = myConnectionsFromData?.connections && [
     ...new Set(myConnectionsFromData?.connections.map((c) => c.to.address)),
   ];
-
-  /*  const allConnectionsFromQuery = useGetAllConnectionsFromWithTwitter(myPubkey, connection);
-  const myFollowingList =
-    !allConnectionsFromQuery.isFetched || !myPubkey
-      ? // we need to keep this undefined until the list is actually loaded
-        undefined
-      : allConnectionsFromQuery.data?.map((u) => u.account.to.toBase58()); */
 
   const [hasMoreFeedEvents, setHasMoreFeedEvents] = useState(true);
 
@@ -233,8 +223,6 @@ const AlphaPage = ({ address }: { address: string }) => {
 
   const feedItems = getFeedItems(feedEvents);
 
-  const fetchMoreIndex = feedItems.length - Math.floor(INFINITE_SCROLL_AMOUNT_INCREMENT / 2);
-
   console.log('Feed', {
     feedEvents,
     feedItems,
@@ -265,7 +253,7 @@ const AlphaPage = ({ address }: { address: string }) => {
               </>
             )}
             {feedEvents.length === 0 && !loading && (
-              <EmptyFeedCTA myFollowingList={myFollowingList} refetch={refetchFeed} />
+              <EmptyFeedCTA myFollowingList={myFollowingList} profilesToFollow={profilesToFollow} refetch={refetchFeed} />
             )}
             {feedItems.map((fEvent) => (
               <FeedCard
@@ -321,7 +309,7 @@ const AlphaPage = ({ address }: { address: string }) => {
             )} */}
         </div>
         <div className="sticky top-10 ml-20 hidden h-fit w-full max-w-sm  xl:block ">
-          <WhoToFollowList myFollowingList={myFollowingList} />
+          <WhoToFollowList myFollowingList={myFollowingList} profilesToFollow={profilesToFollow} />
           {/* <MyActivityList /> */}
           {/*     <TestFeeds /> */}
           <div className="relative  py-10 ">
@@ -391,60 +379,3 @@ function BackToTopBtn() {
     </button>
   );
 }
-
-const TestFeeds = () => {
-  const TEST_FEEDS = [
-    {
-      address: 'GeCRaiFKTbFzBV1UWWFZHBd7kKcCDXZK61QvFpFLen66',
-      handle: 'empty',
-    },
-    {
-      address: 'NWswq7QR7E1i1jkdkddHQUFtRPihqBmJ7MfnMCcUf4H', // kris
-      handle: '@kristianeboe',
-    },
-    {
-      address: 'GJMCz6W1mcjZZD8jK5kNSPzKWDVTD4vHZCgm8kCdiVNS', // kayla
-      handle: '@itskay_k',
-    },
-    {
-      address: '7oUUEdptZnZVhSet4qobU9PtpPfiNUEJ8ftPnrC6YEaa', // dan
-      handle: '@dandelzzz',
-    },
-    {
-      address: 'FeikG7Kui7zw8srzShhrPv2TJgwAn61GU7m8xmaK9GnW', // kevin
-      handle: '@misterkevin_rs',
-    },
-    {
-      address: '2fLigDC5sgXmcVMzQUz3vBqoHSj2yCbAJW1oYX8qbyoR', // Belle
-      handle: '@belle__sol',
-    },
-    {
-      address: '7r8oBPs3vNqgqEG8gnyPWUPgWuScxXyUxtmoLd1bg17F', // Alex
-      handle: '@afkehaya',
-    },
-  ];
-
-  return (
-    <div>
-      <div className="mb-6 flex items-center justify-between border-b border-gray-800 pb-4">
-        <h3 className="m-0 text-base font-medium text-white">
-          Test feeds (click to view their feeds){' '}
-        </h3>
-      </div>
-
-      <div className="space-y-4">
-        {TEST_FEEDS.map((u) => (
-          // <FollowListItem key={p.handle} profile={p} />
-          <div key={u.address} className="flex items-center space-x-4">
-            <ProfilePFP user={u} />
-            <Link passHref href={'/feed?address=' + u.address}>
-              <a className="">
-                <span>{u.handle}</span>
-              </a>
-            </Link>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};

--- a/src/common/components/feed/EmptyFeedCTA.tsx
+++ b/src/common/components/feed/EmptyFeedCTA.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import Button from '../elements/Button';
 import { User, shuffleArray } from './feed.utils';
-import { INFLUENTIAL_WALLETS } from './WhoToFollowList';
 import { useConnection, useAnchorWallet } from '@solana/wallet-adapter-react';
 
 import { Program } from '@holaplex/graph-program';
@@ -14,6 +13,7 @@ import { None } from '../forms/OfferForm';
 
 const EmptyFeedCTA = (props: {
   myFollowingList?: string[];
+  profilesToFollow?: User[];
   refetch: (
     variables?: Partial<OperationVariables> | undefined
   ) => Promise<ApolloQueryResult<None>>;
@@ -29,14 +29,14 @@ const EmptyFeedCTA = (props: {
 
   useEffect(() => {
     if (!myFollowingList) return;
-    // Should probably move this up into a Feed context
-    setTopProfilesToFollow(
-      shuffleArray(INFLUENTIAL_WALLETS.filter((u) => !myFollowingList.includes(u.address))).slice(
-        0,
-        5
-      )
-    );
-  }, [myFollowingList, myFollowingList?.length]);
+    if (props.profilesToFollow) {
+      setTopProfilesToFollow(
+        shuffleArray(
+          props.profilesToFollow.filter((u) => !myFollowingList.includes(u.address))
+        ).slice(0, 5)
+      );
+    }
+  }, [myFollowingList, myFollowingList?.length, props.profilesToFollow]);
 
   const { runActions, hasActionPending } = useContext(MultiTransactionContext);
 

--- a/src/common/components/feed/WhoToFollowList.tsx
+++ b/src/common/components/feed/WhoToFollowList.tsx
@@ -1,11 +1,9 @@
-import { IProfile } from '@/modules/feed/feed.interfaces';
 import { AnchorWallet, useAnchorWallet, useConnection } from '@solana/wallet-adapter-react';
 import { Connection } from '@solana/web3.js';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
-import { useWhoToFollowQuery, WhoToFollowQuery } from 'src/graphql/indexerTypes';
 import { FollowUnfollowButton } from '../elements/FollowUnfollowButton';
-import { getHandle, shuffleArray, User } from './feed.utils';
+import { getHandle, User } from './feed.utils';
 import { ProfilePFP } from './FeedCard';
 
 function FollowListItem({
@@ -23,15 +21,6 @@ function FollowListItem({
     <div className="flex justify-between">
       <div className="flex items-center">
         <div className="mr-4">
-          {/* {user.profile?.pfp ? (
-            <img
-              className="h-8 w-8 rounded-full"
-              src={user.profile?.pfp}
-              alt={'profile picture for ' + user.profile.handle || user.address}
-            />
-          ) : (
-            <div className="h-8 w-8 rounded-full bg-gray-700"></div>
-          )} */}
           <ProfilePFP user={user} />
         </div>
         <Link href={'/profiles/' + user.address + '/nfts'} passHref>
@@ -51,7 +40,7 @@ function FollowListItem({
   );
 }
 
-export default function WhoToFollowList(props: { myFollowingList?: string[] }) {
+export default function WhoToFollowList(props: { myFollowingList?: string[], profilesToFollow?: User[] }) {
   const { connection } = useConnection();
   const anchorWallet = useAnchorWallet();
   const walletConnectionPair = useMemo(
@@ -59,28 +48,23 @@ export default function WhoToFollowList(props: { myFollowingList?: string[] }) {
     [anchorWallet, connection]
   );
 
-  /*   const { data } = useWhoToFollowQuery(); */
-
-  const [topProfilesToFollow, setTopProfilesToFollow] = useState<User[]>(
-    // INFLUENTIAL_WALLETS.slice(0, 10)
-    []
-  );
+  const [topProfilesToFollow, setTopProfilesToFollow] = useState<User[]>([]);
   const [currentFollowingList, setCurrentFollowingList] = useState<string[]>([]);
 
   // initialize based on who you already follow
   useEffect(() => {
-    if (props.myFollowingList && !topProfilesToFollow.length) {
+    if (props.myFollowingList && !topProfilesToFollow.length && props.profilesToFollow) {
       setTopProfilesToFollow(
-        INFLUENTIAL_WALLETS.filter((u) => !props.myFollowingList?.includes(u.address)).splice(0, 5)
+        props.profilesToFollow.filter(u => !props.myFollowingList?.includes(u.address)).slice(0, 5)
       );
       setCurrentFollowingList(props.myFollowingList);
     }
-  }, [props.myFollowingList]);
+  }, [props.myFollowingList, props.profilesToFollow]);
 
   // update
   useEffect(() => {
     if (
-      topProfilesToFollow.length &&
+      topProfilesToFollow.length > 0 &&
       props.myFollowingList &&
       props.myFollowingList.length > 0 &&
       props.myFollowingList.length !== currentFollowingList.length
@@ -96,7 +80,7 @@ export default function WhoToFollowList(props: { myFollowingList?: string[] }) {
           setTopProfilesToFollow(
             [
               ...topProfilesToFollow.slice(0, topProfileIndexToChange),
-              INFLUENTIAL_WALLETS.filter(
+              (props.profilesToFollow || []).filter(
                 (u) =>
                   !topProfilesToFollow.some((tu) => tu.address === u.address) &&
                   !props.myFollowingList?.includes(u.address)
@@ -117,11 +101,6 @@ export default function WhoToFollowList(props: { myFollowingList?: string[] }) {
     <div>
       <div className="mb-6 flex items-center justify-between border-b border-gray-800 pb-4">
         <h3 className="m-0 text-base font-medium text-white">Who to follow</h3>
-        {/* <Link href={'/feed/whotofollow'} passHref>
-          <a>
-            <button className="text-base text-gray-300">See more</button>
-          </a>
-        </Link> */}
       </div>
       <div className="space-y-6">
         {topProfilesToFollow.length === 0 && (
@@ -163,216 +142,3 @@ const LoadingFollowCard = () => (
     <div className={` h-10 w-28 rounded-full bg-gray-800`} />
   </div>
 );
-
-export const INFLUENTIAL_WALLETS: /* Partial<WhoToFollowQuery['followWallets']>  */ User[] =
-  shuffleArray([
-    {
-      address: 'NWswq7QR7E1i1jkdkddHQUFtRPihqBmJ7MfnMCcUf4H',
-      profile: {
-        handle: 'kristianeboe',
-        profileImageUrl: '',
-      },
-      /*   bids: [],
-    nftCounts: {
-      listed: 0,
-      offered: 0,
-      owned: 0,
-    },
-    connectionCounts: {
-      fromCount: 0,
-      toCount: 0,
-    }, */
-    },
-    {
-      address: '3XzWJgu5WEU3GV3mHkWKDYtMXVybUhGeFt7N6uwkcezF',
-      profile: {
-        handle: 'ClassicScuba',
-      },
-    },
-    {
-      address: '2BNABAPHhYAxjpWRoKKnTsWT24jELuvadmZALvP6WvY4',
-      profile: {
-        handle: 'ghost_fried',
-      },
-    },
-    {
-      address: 'DCFWUYqK1iwGzSD3w6SzpwH77GgmbbVX3E2QRtN1qBrj',
-      profile: {
-        handle: 'notjohnlesstudio',
-      },
-    },
-    {
-      address: 'x31BQteSUcoLcatn57pUPh1ATqDkGSBti4KpnXbqjMq',
-      profile: {
-        handle: 'b2kdaman',
-      },
-    },
-    {
-      address: '14kVL6sWSc4oX9rwcJU7aMHMLMjsEfpXcAJf68kmsMeP',
-      profile: {
-        handle: '64jooski',
-      },
-    },
-    {
-      address: '3StkrkMEmdiu9nER5qM3fNR1fCMdawUhGsihF2UkXrPP',
-      profile: {
-        handle: 'earlyishadopter',
-      },
-    },
-    {
-      address: 'DgzWqku67fPeuWgmyZbNa7U7yicKRhbjM7nB86Yx2ojQ',
-      profile: {
-        handle: 'erhancrypto',
-      },
-    },
-    {
-      address: 'Dz3BJenPAMziCBhJFGwUxvu3qhMUuLch8NjoZdfP9xsa',
-      profile: {
-        handle: 'js',
-      },
-    },
-    {
-      address: 'AwiRcagxnT8NLnJeS8ScVcq2Y9f5VeJUfyfR5AXmVFfh',
-      profile: {
-        handle: 'N8Solomon',
-      },
-    },
-    {
-      address: 'AXXRH6NVXjUNxi6GvVWV4Pp6q7k9xkqeqHhRx8sW41TX',
-      profile: {
-        handle: 'Pixeltoy',
-      },
-    },
-    {
-      address: 'CPkXvmoLnru2UX9JcDXLykKkGyTCCYJ67LVZdYahASyh',
-      profile: {
-        // handle: 'Ted // SlimeyOctopus',
-      },
-    },
-    {
-      address: '79j2yWfDHnAU3Aq4yfoTcE9KCHCDo2m54aL4te67683Q',
-      profile: {
-        handle: 'TheObserverNft',
-      },
-    },
-    {
-      address: 'Fh2rUc2CrMTp6H7t1CGnG4aXhWn7BzPPQBU2KkgR4jeh',
-      profile: {
-        handle: 'twxcrypto',
-      },
-    },
-    {
-      address: 'gNEt8EeWqdcSpebQXZ8YVnBC9k5yKp2WGvnA9HR8RzQ',
-      profile: {
-        handle: 'wgarrettdavis',
-      },
-    },
-    {
-      address: 'zenom3SnXK6k2UJm73jRQ1n8U7KkLPrTypDatKjGxoL',
-      profile: {
-        handle: 'zen0m',
-      },
-    },
-    {
-      address: 'Er6QJPusC1JsUqevTjFKXtYHbgCtJkyo1DNjEBWevWut',
-      profile: {
-        handle: '0xbustos',
-      },
-    },
-    {
-      address: 'HLSgM1a7wSufVwe1NrPPR22ynY2aPsH8a1XQfqFsQiqY',
-      profile: {
-        handle: '0xCelon',
-      },
-    },
-    {
-      address: 'BjSaYdgdWtBNXGJmy6cuTzxYzLcxvn4Anw6yrWsgKdNm',
-      profile: {
-        handle: 'PrimitiveMoney',
-      },
-    },
-    {
-      address: '8t6BxNBe7pM8YwvG4JUQxi1W9PYfuphrYcUiJF99oWsP',
-      profile: {
-        handle: 'RainneN23',
-      },
-    },
-    {
-      address: '4ZjYSCH3Sib9iMSM3QN2sL2kwxNcXG2P4XCemSC2hsyb',
-      profile: {
-        handle: 'TheOnlyNom',
-      },
-    },
-    {
-      address: 'GcpdC1iUtfiQ48B6dn7bcM2Ax13R6TDom65jQJiTD18G',
-      profile: {
-        handle: 'adam_ape_',
-      },
-    },
-    {
-      address: 'xYwSUQv7DX62XGo4XXFAQRSTwtS1NrWz8rifR7Gppeg',
-      profile: {
-        handle: 'Crypt0xG',
-      },
-    },
-    {
-      address: 'A1Fk3zhtamLixGStRFc4eBd3pVodoFrNRbVFCaPaPJBu',
-      profile: {
-        handle: 'itsMcNatt',
-      },
-    },
-    {
-      address: 'B3jtSCpXQpMZR5r5m87854bgMj5veHwz9idjd22eVrP7',
-      profile: {
-        handle: 'kknorikami',
-      },
-    },
-    {
-      address: 'GpnKen3QMaLc1CzFsoy8UbcbPwEXRXb5k2qTkTcUa3RX',
-      profile: {
-        handle: 'MattSolana',
-      },
-    },
-    {
-      address: 'H4dfSserFhYBswmPMF3FdYEbu4aj1AQt7RSXRyVqVjaS',
-      profile: {
-        handle: 'poohaus',
-      },
-    },
-    {
-      address: '4Jb3dS76hxcBXKZDkwx3KC4NSMXoTKsyXfwW18apS4vZ',
-      profile: {
-        handle: 'S0Ltoshi',
-      },
-    },
-    {
-      address: 'yTM5APEbWb1GBBtgsjzTF6ZYw5pWxqCr7qKykWW7qLS',
-      profile: {
-        handle: 'Solchemist',
-      },
-    },
-    {
-      address: '2TKEfKKLreKYykZMCKiFMYhhkKFxajfSBeKNZ8rFa6qt',
-      profile: {
-        // handle: 'Good_Brice_',
-      },
-    },
-    {
-      address: 'CsxZxjL19pJ3DM4yyDZDePgCWj6m7Lm9htwHggBbgP1r',
-      profile: {
-        handle: 'howl33333',
-      },
-    },
-    {
-      address: '57DsAWRijeENrhb4RdKiLjKzLF1V8f1J2D8mCNvGMSPu',
-      profile: {
-        // handle: 'quincy_sol',
-      },
-    },
-    {
-      address: 'DWPpeotxT2Q1m1BDzuycQktDe6VnVejLiPWsjfwG6Nb7',
-      profile: {
-        handle: 'Sunless_1',
-      },
-    },
-  ]);

--- a/src/common/components/feed/feed.utils.ts
+++ b/src/common/components/feed/feed.utils.ts
@@ -3,16 +3,12 @@ import { LAMPORTS_PER_SOL } from '@solana/web3.js';
 import {
   BidReceipt,
   FeedQuery,
-  FollowEvent,
-  ListingEvent,
   ListingReceipt,
   MintEvent,
-  OfferEvent,
   PurchaseReceipt,
 } from 'src/graphql/indexerTypes';
 
 type FeedEventTypes = FeedItem['__typename'];
-type Profile = MintEvent['profile'];
 export type FeedQueryEvent = FeedQuery['feedEvents'][0];
 type QueryNFT =
   | MintEvent['nft']

--- a/src/graphql/feed/whoToFollow.graphql
+++ b/src/graphql/feed/whoToFollow.graphql
@@ -1,29 +1,9 @@
-query whoToFollow($limit: Int = 25, $offset: Int = 0) {
-  followWallets(limit: $limit, offset: $offset) {
-    __typename
+query whoToFollow($wallet: PublicKey!, $limit: Int!, $offset: Int = 0) {
+  followWallets(wallet: $wallet, limit: $limit, offset: $offset) {
+    address
     profile {
       handle
-      profileImageUrl
-    }
-    address
-    bids {
-      lastBidTime
-      listing {
-        nfts {
-          address
-          name
-          image
-        }
-      }
-    }
-    connectionCounts {
-      fromCount
-      toCount
-    }
-    nftCounts {
-      owned
-      offered
-      listed
+      profileImageUrlLowres
     }
   }
 }

--- a/src/graphql/indexerTypes.ssr.ts
+++ b/src/graphql/indexerTypes.ssr.ts
@@ -646,12 +646,13 @@ export type FeedQueryVariables = Exact<{
 export type FeedQuery = { __typename?: 'QueryRoot', feedEvents: Array<{ __typename: 'FollowEvent', feedEventId: string, createdAt: any, walletAddress: string, graphConnectionAddress: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, connection?: { __typename?: 'GraphConnection', address: string, from: { __typename?: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }, to: { __typename?: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null } } | null } | { __typename: 'ListingEvent', feedEventId: string, createdAt: any, walletAddress: string, lifecycle: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, listing?: { __typename?: 'ListingReceipt', address: string, bookkeeper: any, seller: any, price: any, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | null } | { __typename: 'MintEvent', feedEventId: string, createdAt: any, walletAddress: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | { __typename: 'OfferEvent', feedEventId: string, createdAt: any, walletAddress: string, lifecycle: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, offer?: { __typename?: 'BidReceipt', address: string, buyer: any, price: any, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | null } | { __typename: 'PurchaseEvent', feedEventId: string, createdAt: any, walletAddress: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, purchase?: { __typename?: 'PurchaseReceipt', address: string, buyer: any, seller: any, price: any, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | null }> };
 
 export type WhoToFollowQueryVariables = Exact<{
-  limit?: InputMaybe<Scalars['Int']>;
+  wallet: Scalars['PublicKey'];
+  limit: Scalars['Int'];
   offset?: InputMaybe<Scalars['Int']>;
 }>;
 
 
-export type WhoToFollowQuery = { __typename?: 'QueryRoot', followWallets: Array<{ __typename: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, bids: Array<{ __typename?: 'Bid', lastBidTime: string, listing?: { __typename?: 'Listing', nfts: Array<{ __typename?: 'Nft', address: string, name: string, image: string }> } | null }>, connectionCounts: { __typename?: 'ConnectionCounts', fromCount: number, toCount: number }, nftCounts: { __typename?: 'WalletNftCount', owned: number, offered: number, listed: number } }> };
+export type WhoToFollowQuery = { __typename?: 'QueryRoot', followWallets: Array<{ __typename?: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrlLowres: string } | null }> };
 
 export type FeaturedBuyNowListingsQueryVariables = Exact<{
   marketplace: Scalars['String'];
@@ -1224,32 +1225,12 @@ export const FeedDocument = gql`
 }
     `;
 export const WhoToFollowDocument = gql`
-    query whoToFollow($limit: Int = 25, $offset: Int = 0) {
-  followWallets(limit: $limit, offset: $offset) {
-    __typename
+    query whoToFollow($wallet: PublicKey!, $limit: Int!, $offset: Int = 0) {
+  followWallets(wallet: $wallet, limit: $limit, offset: $offset) {
+    address
     profile {
       handle
-      profileImageUrl
-    }
-    address
-    bids {
-      lastBidTime
-      listing {
-        nfts {
-          address
-          name
-          image
-        }
-      }
-    }
-    connectionCounts {
-      fromCount
-      toCount
-    }
-    nftCounts {
-      owned
-      offered
-      listed
+      profileImageUrlLowres
     }
   }
 }
@@ -1945,7 +1926,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     feed(variables: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeedQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    whoToFollow(variables?: WhoToFollowQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<WhoToFollowQuery> {
+    whoToFollow(variables: WhoToFollowQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<WhoToFollowQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<WhoToFollowQuery>(WhoToFollowDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'whoToFollow', 'query');
     },
     featuredBuyNowListings(variables: FeaturedBuyNowListingsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeaturedBuyNowListingsQuery> {

--- a/src/graphql/indexerTypes.ts
+++ b/src/graphql/indexerTypes.ts
@@ -646,12 +646,13 @@ export type FeedQueryVariables = Exact<{
 export type FeedQuery = { __typename?: 'QueryRoot', feedEvents: Array<{ __typename: 'FollowEvent', feedEventId: string, createdAt: any, walletAddress: string, graphConnectionAddress: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, connection?: { __typename?: 'GraphConnection', address: string, from: { __typename?: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }, to: { __typename?: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null } } | null } | { __typename: 'ListingEvent', feedEventId: string, createdAt: any, walletAddress: string, lifecycle: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, listing?: { __typename?: 'ListingReceipt', address: string, bookkeeper: any, seller: any, price: any, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | null } | { __typename: 'MintEvent', feedEventId: string, createdAt: any, walletAddress: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | { __typename: 'OfferEvent', feedEventId: string, createdAt: any, walletAddress: string, lifecycle: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, offer?: { __typename?: 'BidReceipt', address: string, buyer: any, price: any, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | null } | { __typename: 'PurchaseEvent', feedEventId: string, createdAt: any, walletAddress: string, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, purchase?: { __typename?: 'PurchaseReceipt', address: string, buyer: any, seller: any, price: any, nft?: { __typename?: 'Nft', name: string, image: string, description: string, sellerFeeBasisPoints: number, primarySaleHappened: boolean, address: string, mintAddress: string, owner?: { __typename?: 'NftOwner', address: string, associatedTokenAccountAddress: string, twitterHandle?: string | null } | null, creators: Array<{ __typename?: 'NftCreator', address: string, position?: number | null, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null }> } | null } | null }> };
 
 export type WhoToFollowQueryVariables = Exact<{
-  limit?: InputMaybe<Scalars['Int']>;
+  wallet: Scalars['PublicKey'];
+  limit: Scalars['Int'];
   offset?: InputMaybe<Scalars['Int']>;
 }>;
 
 
-export type WhoToFollowQuery = { __typename?: 'QueryRoot', followWallets: Array<{ __typename: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrl: string } | null, bids: Array<{ __typename?: 'Bid', lastBidTime: string, listing?: { __typename?: 'Listing', nfts: Array<{ __typename?: 'Nft', address: string, name: string, image: string }> } | null }>, connectionCounts: { __typename?: 'ConnectionCounts', fromCount: number, toCount: number }, nftCounts: { __typename?: 'WalletNftCount', owned: number, offered: number, listed: number } }> };
+export type WhoToFollowQuery = { __typename?: 'QueryRoot', followWallets: Array<{ __typename?: 'Wallet', address: any, profile?: { __typename?: 'TwitterProfile', handle: string, profileImageUrlLowres: string } | null }> };
 
 export type FeaturedBuyNowListingsQueryVariables = Exact<{
   marketplace: Scalars['String'];
@@ -1373,32 +1374,12 @@ export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;
 export type FeedLazyQueryHookResult = ReturnType<typeof useFeedLazyQuery>;
 export type FeedQueryResult = Apollo.QueryResult<FeedQuery, FeedQueryVariables>;
 export const WhoToFollowDocument = gql`
-    query whoToFollow($limit: Int = 25, $offset: Int = 0) {
-  followWallets(limit: $limit, offset: $offset) {
-    __typename
+    query whoToFollow($wallet: PublicKey!, $limit: Int!, $offset: Int = 0) {
+  followWallets(wallet: $wallet, limit: $limit, offset: $offset) {
+    address
     profile {
       handle
-      profileImageUrl
-    }
-    address
-    bids {
-      lastBidTime
-      listing {
-        nfts {
-          address
-          name
-          image
-        }
-      }
-    }
-    connectionCounts {
-      fromCount
-      toCount
-    }
-    nftCounts {
-      owned
-      offered
-      listed
+      profileImageUrlLowres
     }
   }
 }
@@ -1416,12 +1397,13 @@ export const WhoToFollowDocument = gql`
  * @example
  * const { data, loading, error } = useWhoToFollowQuery({
  *   variables: {
+ *      wallet: // value for 'wallet'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *   },
  * });
  */
-export function useWhoToFollowQuery(baseOptions?: Apollo.QueryHookOptions<WhoToFollowQuery, WhoToFollowQueryVariables>) {
+export function useWhoToFollowQuery(baseOptions: Apollo.QueryHookOptions<WhoToFollowQuery, WhoToFollowQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useQuery<WhoToFollowQuery, WhoToFollowQueryVariables>(WhoToFollowDocument, options);
       }

--- a/src/layouts/FeedLayout.tsx
+++ b/src/layouts/FeedLayout.tsx
@@ -1,19 +1,11 @@
-import SocialLinks from '@/common/components/elements/SocialLinks';
-import { MyActivityList } from '@/common/components/feed/MyActivityList';
 import WhoToFollowList from '@/common/components/feed/WhoToFollowList';
 import Footer, { SmallFooter } from '@/common/components/home/Footer';
 import classNames from 'classnames';
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { Tab } from '@headlessui/react';
-import { ProfileHandle, ProfilePFP } from '@/common/components/feed/FeedCard';
 import { useAnchorWallet } from '@solana/wallet-adapter-react';
-import EmptyFeedCTA from '@/common/components/feed/EmptyFeedCTA';
 import { EmptyStateCTA } from '@/common/components/feed/EmptyStateCTA';
 import {
   useAllConnectionsFromLazyQuery,
-  useAllConnectionsFromQuery,
 } from 'src/graphql/indexerTypes';
 
 type FeedType = 'Following' | 'Discovery';
@@ -108,36 +100,10 @@ export default function FeedLayout({ children }: { children: any }) {
     <div className="container mx-auto mt-10 px-6 pb-20  xl:px-44  ">
       <div className="mt-12 flex justify-between">
         <div className="mx-auto w-full  sm:w-[600px] xl:mx-0 ">
-          {/*           <div className="flex space-x-1   p-1">
-            <Tab title={'Your Feed'} selected={feedTabSelected} url="/alpha" />
-            <Tab title={'Discovery'} selected={!feedTabSelected} url="/feed/discovery" />
-          </div> */}
           {children}
         </div>
         <div className="sticky top-10 ml-20 hidden h-fit w-full max-w-sm  xl:block ">
           <WhoToFollowList myFollowingList={myFollowingList} />
-          {/* <MyActivityList /> */}
-          {/* <div>
-            <div className="mb-6 flex items-center justify-between border-b border-gray-800 pb-4">
-              <h3 className="m-0 text-base font-medium text-white">
-                Test feeds (click to view their feeds){' '}
-              </h3>
-            </div>
-
-            <div className="space-y-4">
-              {TEST_FEEDS.map((u) => (
-                // <FollowListItem key={p.handle} profile={p} />
-                <div key={u.address} className="flex items-center space-x-4">
-                  <ProfilePFP user={u} />
-                  <Link passHref href={'/feed?address=' + u.address}>
-                    <a className="">
-                      <span>{u.handle}</span>
-                    </a>
-                  </Link>
-                </div>
-              ))}
-            </div>
-          </div> */}
           <div className="relative  py-10 ">
             <div className="absolute  inset-0 flex items-center" aria-hidden="true">
               <div className="w-full border-t border-gray-800" />

--- a/src/layouts/FeedLayout.tsx
+++ b/src/layouts/FeedLayout.tsx
@@ -5,42 +5,9 @@ import React, { useEffect, useState } from 'react';
 import { useAnchorWallet } from '@solana/wallet-adapter-react';
 import { EmptyStateCTA } from '@/common/components/feed/EmptyStateCTA';
 import {
-  useAllConnectionsFromLazyQuery,
+  useAllConnectionsFromLazyQuery, useWhoToFollowQuery,
 } from 'src/graphql/indexerTypes';
-
-type FeedType = 'Following' | 'Discovery';
-const Feeds: FeedType[] = ['Following', 'Discovery'];
-
-const TEST_FEEDS = [
-  {
-    address: 'GeCRaiFKTbFzBV1UWWFZHBd7kKcCDXZK61QvFpFLen66',
-    handle: 'empty',
-  },
-  {
-    address: 'NWswq7QR7E1i1jkdkddHQUFtRPihqBmJ7MfnMCcUf4H', // kris
-    handle: '@kristianeboe',
-  },
-  {
-    address: 'GJMCz6W1mcjZZD8jK5kNSPzKWDVTD4vHZCgm8kCdiVNS', // kayla
-    handle: '@itskay_k',
-  },
-  {
-    address: '7oUUEdptZnZVhSet4qobU9PtpPfiNUEJ8ftPnrC6YEaa', // dan
-    handle: '@dandelzzz',
-  },
-  {
-    address: 'FeikG7Kui7zw8srzShhrPv2TJgwAn61GU7m8xmaK9GnW', // kevin
-    handle: '@misterkevin_rs',
-  },
-  {
-    address: '2fLigDC5sgXmcVMzQUz3vBqoHSj2yCbAJW1oYX8qbyoR', // Belle
-    handle: '@belle__sol',
-  },
-  {
-    address: '7r8oBPs3vNqgqEG8gnyPWUPgWuScxXyUxtmoLd1bg17F', // Alex
-    handle: '@afkehaya',
-  },
-];
+import { User } from '@/common/components/feed/feed.utils';
 
 export default function FeedLayout({ children }: { children: any }) {
   // Please don't remove the commented out code about the tab structure yet, it might be used soon // Kris
@@ -70,6 +37,9 @@ export default function FeedLayout({ children }: { children: any }) {
   });
 
   const myFollowingList: string[] | undefined = data?.connections.map((c) => c.to.address);
+
+  const {data: whoToFollowData} = useWhoToFollowQuery({variables: {wallet: anchorWallet?.publicKey, limit: 25}});
+  const profilesToFollow: User[] = (whoToFollowData?.followWallets || []).map(u => ({address: u.address, profile: {handle: u.profile?.handle, profileImageUrl: u.profile?.profileImageUrlLowres}}));
 
   useEffect(() => {
     if (!anchorWallet) {
@@ -103,7 +73,7 @@ export default function FeedLayout({ children }: { children: any }) {
           {children}
         </div>
         <div className="sticky top-10 ml-20 hidden h-fit w-full max-w-sm  xl:block ">
-          <WhoToFollowList myFollowingList={myFollowingList} />
+          <WhoToFollowList myFollowingList={myFollowingList} profilesToFollow={profilesToFollow}/>
           <div className="relative  py-10 ">
             <div className="absolute  inset-0 flex items-center" aria-hidden="true">
               <div className="w-full border-t border-gray-800" />


### PR DESCRIPTION
This PR replaces the hardcoded profiles to follow in alpha with a request to the backend.

# Changes
- Changed the Who to Follow query to accept a wallet address, so it only returns the wallets that are not already followed, though I left in the "filter by unfollowed" step in components for updating top follows (`src/graphql/**`)
- Use `useWhoToFollowQuery` in alpha page (`index.tsx`, `FeedLayout.tsx`)
- Pass profiles to follow data to components that were using the hardcoded list before (`EmptyFeedCTA.tsx`, `WhoToFollowList.tsx`)
- Removed unused imports and commented code throughout.

Closes #446 