### PR TITLE
featured profiles fetch poc

### DIFF
--- a/src/common/components/elements/ProfilePreviewCard.tsx
+++ b/src/common/components/elements/ProfilePreviewCard.tsx
@@ -1,69 +1,57 @@
 import { useAnalytics } from '@/common/context/AnalyticsProvider';
+import { QueryContext, useProfilePreview } from '@/common/hooks/home';
 import { getFallbackImage } from '@/modules/utils/image';
 import { showFirstAndLastFour } from '@/modules/utils/string';
-import { ProfilePreviewData } from '@/types/types';
 import { useAnchorWallet, useConnection } from '@solana/wallet-adapter-react';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { useState, useEffect, useCallback, FC, VFC } from 'react';
-import { useProfilePreviewLazyQuery, useIsXFollowingYLazyQuery } from 'src/graphql/indexerTypes';
+import { useCallback, FC, VFC } from 'react';
+import { useIsXFollowingYLazyQuery } from 'src/graphql/indexerTypes';
 import { AvatarImage } from './Avatar';
 import { FollowUnfollowButton } from './FollowUnfollowButton';
 
+export interface ProfilePreviewData {
+  address: string;
+  nftsOwned: number;
+  nftsCreated: number;
+  handle?: string;
+  profileImageUrl?: string;
+  bannerImageUrl?: string;
+}
+
 export interface ProfilePreviewProps {
   address: string;
-  data?: ProfilePreviewData;
   onInsufficientData: (address: string) => void;
 }
 
 export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element {
   const { track } = useAnalytics();
-  const [dataQuery, dataQueryContext] = useProfilePreviewLazyQuery();
-  const [finalData, setFinalData] = useState<ProfilePreviewData>({
-    address: props.address,
-    nftCounts: {},
-    profile: {},
-  });
-
-  useEffect(
-    () => {
-      async function queryAndSetData() {
-        await dataQuery({ variables: { address: props.address } });
-        if (dataQueryContext.data) {
-          setFinalData(dataQueryContext.data.wallet as ProfilePreviewData);
-        }
-      }
-
-      if (props.data) setFinalData(props.data);
-      else queryAndSetData();
-    },
-    // dont want to include the dataQuery.data as this will re-trigger the request
-    [dataQuery, props.data, props.address]
-  );
-
-  useEffect(() => {
-    if ((props.data || !dataQueryContext.loading) && !previewDataAreSufficient(finalData)) {
-      props.onInsufficientData(props.address);
-    }
-  }, [props.address, props.onInsufficientData, dataQueryContext.loading, finalData, props.data]);
+  const queryContext: QueryContext<ProfilePreviewData> = useProfilePreview(props.address);
 
   const onClickProfileLink = useCallback(() => {
     track('Profile Selected', {
       event_category: 'Discovery',
-      event_label: props.data ? props.data.address : 'unknown-address',
+      event_label: props.address,
     });
-  }, [props.data, track]);
+  }, [track, props.address]);
 
-  if (!previewDataAreSufficient(finalData)) {
+  if ((!queryContext.loading && !queryContext.data) || queryContext.error) {
+    props.onInsufficientData(props.address);
+    return <></>;
+  }
+
+  if (queryContext.loading) {
     return <ProfilePreviewLoadingCard />;
   }
 
-  const profileUrl: string = `/profiles/${finalData.address}`;
-  const handleString: string = finalData.profile?.handle
-    ? `@${finalData.profile.handle}`
-    : showFirstAndLastFour(finalData.address);
-  const ownNftsString: string = (finalData.nftCounts.owned ?? 0).toLocaleString();
-  const createdNftsString: string = (finalData.nftCounts.created ?? 0).toLocaleString();
+  const data: ProfilePreviewData = queryContext.data!;
+
+  const profileUrl: string = `/profiles/${props.address}`;
+  const handleString: string = data.handle
+    ? `@${data.handle}`
+    : showFirstAndLastFour(props.address);
+  const ownNftsString: string = data.nftsOwned.toLocaleString();
+  const createdNftsString: string = data.nftsCreated.toLocaleString();
 
   return (
     <PreviewContainer>
@@ -81,8 +69,8 @@ export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element 
         {/* preview image */}
         <div className="relative h-[47%] flex-shrink-0 overflow-clip">
           <img
-            src={finalData.profile?.bannerImageUrl ?? getFallbackImage()}
-            alt={`${finalData.address} banner`}
+            src={data.bannerImageUrl ?? getFallbackImage()}
+            alt={`${props.address} banner`}
             className="flex min-h-full min-w-full object-cover"
             // provide a fallback image in case the banner isnt found
             onError={({ currentTarget }) => {
@@ -98,13 +86,13 @@ export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element 
           <div className="relative flex h-8 items-end justify-end lg:h-10">
             <div className="absolute left-0 bottom-0 aspect-square h-16 w-16 md:h-12 md:w-12 lg:h-20 lg:w-20">
               <AvatarImage
-                src={finalData.profile?.profileImageUrlHighres ?? getFallbackImage()}
+                src={data.profileImageUrl ?? getFallbackImage()}
                 border
                 borderClass="border-4 border-gray-900"
               />
             </div>
             <FollowUnfollowButtonDataWrapper
-              targetPubkey={finalData.address}
+              targetPubkey={props.address}
               className="pointer-events-auto z-50 flex"
             />
           </div>
@@ -126,10 +114,6 @@ export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element 
       </div>
     </PreviewContainer>
   );
-}
-
-function previewDataAreSufficient(data?: ProfilePreviewData): boolean {
-  return data != undefined && data.address != undefined && data.nftCounts != undefined;
 }
 
 export function ProfilePreviewLoadingCard(): JSX.Element {

--- a/src/common/components/elements/ProfilePreviewCard.tsx
+++ b/src/common/components/elements/ProfilePreviewCard.tsx
@@ -40,7 +40,7 @@ export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element 
     return <></>;
   }
 
-  if (queryContext.loading) {
+  if (queryContext.loading || !queryContext.data) {
     return <ProfilePreviewLoadingCard />;
   }
 

--- a/src/common/components/home/FeaturedProfilesSection.tsx
+++ b/src/common/components/home/FeaturedProfilesSection.tsx
@@ -1,57 +1,26 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { HomeSection, HomeSectionCarousel } from 'pages/index';
-import { ProfilePreviewData } from '@/types/types';
-import {
-  useFeaturedProfilesQuery,
-} from 'src/graphql/indexerTypes';
-import {
-  useWallet,
-  WalletContextState,
-} from '@solana/wallet-adapter-react';
 import ProfilePreview from '../elements/ProfilePreviewCard';
+import { QueryContext, useFeaturedProfiles } from '@/common/hooks/home';
 
 const CAROUSEL_ROWS: number = 2;
 const CAROUSEL_COLS: number = 3;
-const CAROUSEL_PAGES: number = 2;
-const N_LISTINGS: number = CAROUSEL_ROWS * CAROUSEL_COLS * CAROUSEL_PAGES;
-
-//TODO remove once other profiles have enough followers to preclude this one in the backend
-const DISALLOWED_PROFILES: string[] = ['ho1aVYd4TDWCi1pMqFvboPPc3J13e4LgWkWzGJpPJty'];
 
 export default function FeaturedProfilesSection(): JSX.Element {
-  const wallet: WalletContextState = useWallet();
-  // initial value hack to get loading card
-  // TODO pass in a loading boolean to bypass loading until the address is known
-  const [featuredProfiles, setFeaturedProfiles] = useState<ProfilePreviewData[]>(
-    [...Array(N_LISTINGS)].map((_) => ({ address: '', profile: {}, nftCounts: {} }))
-  );
-
-  const dataQuery = useFeaturedProfilesQuery({
-    variables: {
-      userWallet: wallet?.publicKey,
-      limit: CAROUSEL_PAGES * CAROUSEL_COLS * CAROUSEL_ROWS,
-    },
-  });
-
-  // get featured profiles once on page load and anytime later when the wallet has been (dis)connected
-  // by making the wallet pubkey one of the dependencies
-  useEffect(() => {
-    if (dataQuery.data?.followWallets && dataQuery.data.followWallets.length > 0) {
-      const profilesToShow = (dataQuery.data.followWallets as ProfilePreviewData[]).filter(
-        (p) => !DISALLOWED_PROFILES.includes(p.address)
-      );
-      setFeaturedProfiles(profilesToShow);
-    }
-  }, [wallet?.publicKey, setFeaturedProfiles, dataQuery.data?.followWallets]);
+  const queryContext: QueryContext<string[]> = useFeaturedProfiles();
+  const [excludedProfiles, setExcludedProfiles] = useState<string[]>([]);
 
   // when the server returns a profile with insufficient data to display the
   //  preview, remove it from the carousel
   const onInsufficientDataForAProfile = useCallback<(profileAddress: string) => void>(
     (profileAddress) => {
-      setFeaturedProfiles(featuredProfiles.filter((p) => p.address !== profileAddress));
+      excludedProfiles.push(profileAddress);
+      setExcludedProfiles(excludedProfiles);
     },
-    [featuredProfiles]
+    [excludedProfiles]
   );
+
+  const featuredProfiles: string[] = (queryContext.data ?? []).filter(a => !excludedProfiles.includes(a));
 
   return (
     <HomeSection>
@@ -63,11 +32,10 @@ export default function FeaturedProfilesSection(): JSX.Element {
       </HomeSection.Header>
       <HomeSection.Body>
         <HomeSectionCarousel rows={CAROUSEL_ROWS} cols={CAROUSEL_COLS}>
-          {featuredProfiles.map((s) => (
-            <HomeSectionCarousel.Item key={s.address} className="p-4">
+          {featuredProfiles.map((a) => (
+            <HomeSectionCarousel.Item key={a} className="p-4">
               <ProfilePreview
-                address={s.address}
-                data={s}
+                address={a}
                 onInsufficientData={onInsufficientDataForAProfile}
               />
             </HomeSectionCarousel.Item>

--- a/src/common/hooks/home.ts
+++ b/src/common/hooks/home.ts
@@ -1,0 +1,84 @@
+import { useWallet, WalletContextState } from '@solana/wallet-adapter-react';
+import { useEffect } from 'react';
+import { FeaturedProfilesQuery, useFeaturedProfilesLazyQuery } from 'src/graphql/indexerTypes';
+import { ProfilePreviewData } from '../components/elements/ProfilePreviewCard';
+
+export interface QueryContext<T> {
+  data?: T | undefined;
+  loading: boolean;
+  error?: Error | undefined;
+}
+
+//TODO remove once other profiles have enough followers to preclude this one in the backend
+const DISALLOWED_PROFILES: string[] = ['ho1aVYd4TDWCi1pMqFvboPPc3J13e4LgWkWzGJpPJty'];
+
+function useFeaturedProfilesData() {
+  const wallet: WalletContextState = useWallet();
+  const [featuredProfilesQuery, queryContext] = useFeaturedProfilesLazyQuery();
+
+  useEffect(() => {
+    async function query(): Promise<void> {
+      await featuredProfilesQuery({ variables: { limit: 25, userWallet: wallet?.publicKey } });
+    }
+
+    if (!queryContext.loading && !queryContext.called) {
+      query();
+    }
+  }, [wallet, featuredProfilesQuery, queryContext.called, queryContext.loading]);
+
+  console.log(queryContext.data);
+
+  return queryContext;
+}
+
+// fetching the list of profiles to feature (only need their address)
+export function useFeaturedProfiles(): QueryContext<string[]> {
+    console.log('useFeaturedProfiles');
+  const queryContext = useFeaturedProfilesData();
+
+  //TODO implement caching of transformed object
+  return {
+    data:
+      queryContext.data?.followWallets
+        .filter((w) => !DISALLOWED_PROFILES.includes(w.address))
+        .map((w) => w.address) ?? [],
+    loading: queryContext.loading,
+    error: queryContext.error,
+  };
+}
+
+// fetching data for a single profile preview card
+export function useProfilePreview(address: string): QueryContext<ProfilePreviewData> {
+  console.log('useProfilePreview');
+    const queryContext = useFeaturedProfilesData();
+
+  const gqlObject: FeaturedProfilesQuery['followWallets'][0] | null | undefined =
+    queryContext.data?.followWallets.find((w) => w.address === address);
+
+  let error: Error | undefined = queryContext.error;
+  if (!error && gqlObject) {
+    if (gqlObject.nftCounts.created === null || gqlObject.nftCounts.created === undefined) {
+      error = new Error('Missing count of NFTs created.');
+    } else if (gqlObject.nftCounts.owned === null || gqlObject.nftCounts.owned === undefined) {
+      error = new Error('Missing count of NFTs collected.');
+    }
+  }
+
+  if (error) return { loading: false, error: error };
+
+  //TODO implement caching of transformed object
+  const data: ProfilePreviewData = {
+    address: gqlObject?.address,
+    nftsOwned: gqlObject?.nftCounts.owned!,
+    nftsCreated: gqlObject?.nftCounts.created!,
+    handle: gqlObject?.profile?.handle,
+    profileImageUrl: gqlObject?.profile?.profileImageUrlHighres,
+    bannerImageUrl: gqlObject?.profile?.bannerImageUrl,
+  };
+
+  return {
+    data: data,
+    loading: queryContext.loading,
+    error: error,
+  };
+}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -51,19 +51,6 @@ export type BuyNowListingPreviewData = {
 };
 
 
-export interface ProfilePreviewData {
-  address: string;
-  profile: {
-    handle?: string;
-    profileImageUrlHighres?: string;
-    bannerImageUrl?: string;
-  }
-  nftCounts: {
-    owned?: number;
-    created?: number;
-  }
-}
-
 interface GraphQLObject {
   __typename: string;
 }


### PR DESCRIPTION
This PR shows how we can leverage hooks to simultaneously

1. execute queries at the page level 
2. allow components to define their own data interfaces
3. abstract away API data structures and client logic
4. keep components narrowly scoped

Notice:
- how much code I was able to delete from the component files when I didnt have to worry about whether some graph-ql data were present or not (because the component's interface dictates what's valid data to pass in) or how/when to update state. 
- how much flatter the data interfaces could become when the inherent nested structure of the Graph QL objects was removed.
- that the outer `FeaturedProfilesSection` component didnt need to pass down, transform, or even know about the data structure of the `ProfilePreview` card. It only has to pass along the key and let the `ProfilePreview` get its own data.

This is not a complete solution (yet), as we should explore how to cache the transformed data rather than re-transform each time the hook is called. We would also want to expose some of the other functionality in Apollo, like refetching, updating, etc.
