### PR TITLE
(indexer/#604) temporarily remove collection fragment

### DIFF
--- a/src/graphql/discover/collections/marketcap.graphql
+++ b/src/graphql/discover/collections/marketcap.graphql
@@ -15,6 +15,8 @@ query discoverCollectionsByMarketCap(
     offset: $offset
     orderDirection: DESC
   ) {
-    ...CollectionPreview
+    mintAddress
+    name
+    image
   }
 }

--- a/src/graphql/discover/collections/volume.graphql
+++ b/src/graphql/discover/collections/volume.graphql
@@ -15,6 +15,8 @@ query discoverCollectionsByVolume(
     offset: $offset
     orderDirection: DESC
   ) {
-    ...CollectionPreview
+    mintAddress
+    name
+    image
   }
 }

--- a/src/graphql/fragments/CollectionPreview.graphql
+++ b/src/graphql/fragments/CollectionPreview.graphql
@@ -1,5 +1,0 @@
-fragment CollectionPreview on Nft {
-  mintAddress
-  name
-  image
-}

--- a/src/graphql/home/home.graphql
+++ b/src/graphql/home/home.graphql
@@ -6,7 +6,7 @@
 # import "../fragments/ListingEventPreview.graphql"
 # import "../fragments/OfferEventPreview.graphql"
 # import "../fragments/CollectionPreview.graphql"
-#import "./ProfileInfo.graphql"
+# import "./ProfileInfo.graphql"
 
 fragment ProfilePreview on Wallet {
   address
@@ -174,7 +174,9 @@ query home(
     offset: 0
     orderDirection: DESC
   ) {
-    ...CollectionPreview
+    mintAddress
+    name
+    image
   }
 
   collectionsFeaturedByMarketCap(
@@ -184,7 +186,9 @@ query home(
     offset: 0
     orderDirection: DESC
   ) {
-    ...CollectionPreview
+    mintAddress
+    name
+    image
   }
 
   followWallets(wallet: $userWallet, limit: $featuredProfileLimit, offset: 0) {

--- a/src/graphql/indexerTypes.ssr.ts
+++ b/src/graphql/indexerTypes.ssr.ts
@@ -33,6 +33,7 @@ export type AhListing = {
   canceledAt?: Maybe<Scalars['DateTimeUtc']>;
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -338,6 +339,7 @@ export type NftActivity = {
   auctionHouse?: Maybe<AuctionHouse>;
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -404,6 +406,7 @@ export type Offer = {
   canceledAt?: Maybe<Scalars['DateTimeUtc']>;
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -457,6 +460,7 @@ export type Purchase = {
   buyer: Scalars['PublicKey'];
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -494,6 +498,7 @@ export type QueryRoot = {
   /** Recommend wallets to follow. */
   followWallets: Array<Wallet>;
   genoHabitat?: Maybe<GenoHabitat>;
+  genoHabitats: Array<GenoHabitat>;
   /** Returns the latest on chain events using the graph_program. */
   latestFeedEvents: Array<FeedEvent>;
   listings: Array<Listing>;
@@ -604,6 +609,25 @@ export type QueryRootFollowWalletsArgs = {
 
 export type QueryRootGenoHabitatArgs = {
   address: Scalars['PublicKey'];
+};
+
+export type QueryRootGenoHabitatsArgs = {
+  elements?: InputMaybe<Array<Scalars['Int']>>;
+  genesis?: InputMaybe<Scalars['Boolean']>;
+  guilds?: InputMaybe<Array<Scalars['Int']>>;
+  harvesters?: InputMaybe<Array<Scalars['String']>>;
+  limit: Scalars['Int'];
+  maxDurability?: InputMaybe<Scalars['Int']>;
+  maxExpiry?: InputMaybe<Scalars['DateTimeUtc']>;
+  maxLevel?: InputMaybe<Scalars['Int']>;
+  maxSequence?: InputMaybe<Scalars['Int']>;
+  minDurability?: InputMaybe<Scalars['Int']>;
+  minExpiry?: InputMaybe<Scalars['DateTimeUtc']>;
+  minLevel?: InputMaybe<Scalars['Int']>;
+  minSequence?: InputMaybe<Scalars['Int']>;
+  offset: Scalars['Int'];
+  owners?: InputMaybe<Array<Scalars['PublicKey']>>;
+  renters?: InputMaybe<Array<Scalars['PublicKey']>>;
 };
 
 export type QueryRootLatestFeedEventsArgs = {
@@ -2376,13 +2400,6 @@ export type WhoToFollowQuery = {
     } | null;
     nftCounts: { __typename?: 'WalletNftCount'; owned: number; created: number };
   }>;
-};
-
-export type CollectionPreviewFragment = {
-  __typename?: 'Nft';
-  mintAddress: string;
-  name: string;
-  image: string;
 };
 
 export type FollowEventPreviewFragment = {
@@ -4751,13 +4768,6 @@ export type SearchQuery = {
   }>;
 };
 
-export const CollectionPreviewFragmentDoc = gql`
-  fragment CollectionPreview on Nft {
-    mintAddress
-    name
-    image
-  }
-`;
 export const ProfileInfoFragmentDoc = gql`
   fragment ProfileInfo on TwitterProfile {
     walletAddress
@@ -5985,10 +5995,11 @@ export const DiscoverCollectionsByMarketCapDocument = gql`
       offset: $offset
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
   }
-  ${CollectionPreviewFragmentDoc}
 `;
 export const DiscoverCollectionsByVolumeDocument = gql`
   query discoverCollectionsByVolume(
@@ -6006,10 +6017,11 @@ export const DiscoverCollectionsByVolumeDocument = gql`
       offset: $offset
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
   }
-  ${CollectionPreviewFragmentDoc}
 `;
 export const DiscoverNftsActiveOffersDocument = gql`
   query discoverNftsActiveOffers($searchTerm: String, $limit: Int!, $offset: Int!) {
@@ -6159,7 +6171,9 @@ export const HomeDocument = gql`
       offset: 0
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
     collectionsFeaturedByMarketCap(
       startDate: "2020-01-01T00:00:00Z"
@@ -6168,7 +6182,9 @@ export const HomeDocument = gql`
       offset: 0
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
     followWallets(wallet: $userWallet, limit: $featuredProfileLimit, offset: 0) {
       ...ProfilePreview
@@ -6199,7 +6215,6 @@ export const HomeDocument = gql`
   ${PurchaseEventPreviewFragmentDoc}
   ${ListingEventPreviewFragmentDoc}
   ${OfferEventPreviewFragmentDoc}
-  ${CollectionPreviewFragmentDoc}
   ${ProfilePreviewFragmentDoc}
   ${BuyNowListingFragmentDoc}
   ${MarketplaceAuctionHouseFragmentDoc}

--- a/src/graphql/indexerTypes.ts
+++ b/src/graphql/indexerTypes.ts
@@ -33,6 +33,7 @@ export type AhListing = {
   canceledAt?: Maybe<Scalars['DateTimeUtc']>;
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -338,6 +339,7 @@ export type NftActivity = {
   auctionHouse?: Maybe<AuctionHouse>;
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -404,6 +406,7 @@ export type Offer = {
   canceledAt?: Maybe<Scalars['DateTimeUtc']>;
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -457,6 +460,7 @@ export type Purchase = {
   buyer: Scalars['PublicKey'];
   createdAt: Scalars['DateTimeUtc'];
   id: Scalars['Uuid'];
+  marketplaceProgramAddress: Scalars['String'];
   metadata: Scalars['PublicKey'];
   nft?: Maybe<Nft>;
   price: Scalars['U64'];
@@ -494,6 +498,7 @@ export type QueryRoot = {
   /** Recommend wallets to follow. */
   followWallets: Array<Wallet>;
   genoHabitat?: Maybe<GenoHabitat>;
+  genoHabitats: Array<GenoHabitat>;
   /** Returns the latest on chain events using the graph_program. */
   latestFeedEvents: Array<FeedEvent>;
   listings: Array<Listing>;
@@ -604,6 +609,25 @@ export type QueryRootFollowWalletsArgs = {
 
 export type QueryRootGenoHabitatArgs = {
   address: Scalars['PublicKey'];
+};
+
+export type QueryRootGenoHabitatsArgs = {
+  elements?: InputMaybe<Array<Scalars['Int']>>;
+  genesis?: InputMaybe<Scalars['Boolean']>;
+  guilds?: InputMaybe<Array<Scalars['Int']>>;
+  harvesters?: InputMaybe<Array<Scalars['String']>>;
+  limit: Scalars['Int'];
+  maxDurability?: InputMaybe<Scalars['Int']>;
+  maxExpiry?: InputMaybe<Scalars['DateTimeUtc']>;
+  maxLevel?: InputMaybe<Scalars['Int']>;
+  maxSequence?: InputMaybe<Scalars['Int']>;
+  minDurability?: InputMaybe<Scalars['Int']>;
+  minExpiry?: InputMaybe<Scalars['DateTimeUtc']>;
+  minLevel?: InputMaybe<Scalars['Int']>;
+  minSequence?: InputMaybe<Scalars['Int']>;
+  offset: Scalars['Int'];
+  owners?: InputMaybe<Array<Scalars['PublicKey']>>;
+  renters?: InputMaybe<Array<Scalars['PublicKey']>>;
 };
 
 export type QueryRootLatestFeedEventsArgs = {
@@ -2376,13 +2400,6 @@ export type WhoToFollowQuery = {
     } | null;
     nftCounts: { __typename?: 'WalletNftCount'; owned: number; created: number };
   }>;
-};
-
-export type CollectionPreviewFragment = {
-  __typename?: 'Nft';
-  mintAddress: string;
-  name: string;
-  image: string;
 };
 
 export type FollowEventPreviewFragment = {
@@ -4751,13 +4768,6 @@ export type SearchQuery = {
   }>;
 };
 
-export const CollectionPreviewFragmentDoc = gql`
-  fragment CollectionPreview on Nft {
-    mintAddress
-    name
-    image
-  }
-`;
 export const ProfileInfoFragmentDoc = gql`
   fragment ProfileInfo on TwitterProfile {
     walletAddress
@@ -6317,10 +6327,11 @@ export const DiscoverCollectionsByMarketCapDocument = gql`
       offset: $offset
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
   }
-  ${CollectionPreviewFragmentDoc}
 `;
 
 /**
@@ -6393,10 +6404,11 @@ export const DiscoverCollectionsByVolumeDocument = gql`
       offset: $offset
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
   }
-  ${CollectionPreviewFragmentDoc}
 `;
 
 /**
@@ -6866,7 +6878,9 @@ export const HomeDocument = gql`
       offset: 0
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
     collectionsFeaturedByMarketCap(
       startDate: "2020-01-01T00:00:00Z"
@@ -6875,7 +6889,9 @@ export const HomeDocument = gql`
       offset: 0
       orderDirection: DESC
     ) {
-      ...CollectionPreview
+      mintAddress
+      name
+      image
     }
     followWallets(wallet: $userWallet, limit: $featuredProfileLimit, offset: 0) {
       ...ProfilePreview
@@ -6906,7 +6922,6 @@ export const HomeDocument = gql`
   ${PurchaseEventPreviewFragmentDoc}
   ${ListingEventPreviewFragmentDoc}
   ${OfferEventPreviewFragmentDoc}
-  ${CollectionPreviewFragmentDoc}
   ${ProfilePreviewFragmentDoc}
   ${BuyNowListingFragmentDoc}
   ${MarketplaceAuctionHouseFragmentDoc}

--- a/src/views/discover/discover.hooks.ts
+++ b/src/views/discover/discover.hooks.ts
@@ -19,7 +19,7 @@ import {
   useDiscoverProfilesAllLazyQuery,
 } from 'src/graphql/indexerTypes';
 import {
-  CollectionPreviewFragment,
+  // CollectionPreviewFragment,
   DiscoverCollectionsByVolumeQuery,
   DiscoverNftsBuyNowQuery,
   DiscoverProfilesAllQuery,
@@ -240,7 +240,8 @@ function useDiscoverCollectionsQuery(
 }
 
 function transformCollectionCardData(
-  cardData: CollectionPreviewFragment
+  // cardData: CollectionPreviewFragment
+  cardData: DiscoverCollectionsByMarketCapQuery['collectionsFeaturedByMarketCap'][0]
 ): CollectionPreviewCardData {
   return {
     address: cardData.mintAddress,

--- a/src/views/home/home.hooks.ts
+++ b/src/views/home/home.hooks.ts
@@ -6,7 +6,7 @@ import { PublicKey } from '@solana/web3.js';
 import { HomeData } from 'src/pages';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  CollectionPreviewFragment,
+  // CollectionPreviewFragment,
   useHomeQuery,
   BuyNowListingFragment,
   HomeQuery,
@@ -142,7 +142,10 @@ function transformFeaturedCollectionsByMarketCap(
   return result;
 }
 
-function transformCollectionPreview(data: CollectionPreviewFragment): CollectionPreviewCardData {
+// function transformCollectionPreview(data: CollectionPreviewFragment): CollectionPreviewCardData {
+function transformCollectionPreview(
+  data: HomeQuery['collectionsFeaturedByMarketCap'][0]
+): CollectionPreviewCardData {
   return {
     address: data.mintAddress,
     imageUrl: data.image,


### PR DESCRIPTION
This PR is a temporary factor to remove references to the `Nft` type returned for collection NFTs. Making this change allows us to release [this indexer PR](https://github.com/holaplex/indexer/pull/612) without breaking holaplex. I will follow up the indexer release with [this holaplex PR](https://github.com/holaplex/holaplex/pull/652/files), which will refactor to use the new `Collection` type returned by some indexer queries.