### PR TITLE
#630: fix collection stats

### DIFF
--- a/src/components/CollectionPreviewCard.tsx
+++ b/src/components/CollectionPreviewCard.tsx
@@ -2,6 +2,7 @@ import { QueryContext } from '@/hooks/useApolloQuery';
 import { getFallbackImage } from '@/modules/utils/image';
 import clsx from 'clsx';
 import { imgOpt } from 'src/lib/utils';
+import { SolIcon } from './Price';
 
 export interface CollectionPreviewCardData {
   address: string;
@@ -133,7 +134,7 @@ export function CollectionPreviewCard(props: CollectionPreviewCardProps): JSX.El
               ['lg:text-sm']
             )}
           >
-            <span>{`Collection of ${nftCountStr}`}</span>
+            <span className="text-sm">{`${nftCountStr} NFTs`}</span>
           </div>
         )
       }
@@ -148,7 +149,13 @@ export function CollectionPreviewCard(props: CollectionPreviewCardProps): JSX.El
               ['lg:text-sm']
             )}
           >
-            <span>Floor: {props.context.data?.floorPriceSol} SOL</span>
+            <span
+              className="flex flex-row flex-nowrap items-center justify-start space-x-1 text-sm"
+              title="floor price"
+            >
+              <SolIcon className="h-3 w-3" stroke="white" />{' '}
+              <span>{props.context.data?.floorPriceSol}</span>
+            </span>
           </div>
         )
       }

--- a/src/views/discover/discover.hooks.ts
+++ b/src/views/discover/discover.hooks.ts
@@ -26,6 +26,7 @@ import {
   MarketplaceAuctionHouseFragment,
   NftCardFragment,
 } from 'src/graphql/indexerTypes.ssr';
+import { LAMPORTS_PER_SOL } from '@solana/web3.js';
 
 interface DiscoverNftsQueryParams {
   searchTerm?: string | null | undefined;
@@ -245,7 +246,7 @@ function transformCollectionCardData(
     address: cardData.nft.mintAddress,
     name: cardData.nft.name,
     imageUrl: cardData.nft.image,
-    floorPriceSol: cardData.floorPrice ?? 0,
+    floorPriceSol: (cardData.floorPrice ?? 0) / LAMPORTS_PER_SOL,
     nftCount: cardData.nftCount ?? 0,
   };
 }

--- a/src/views/home/home.hooks.ts
+++ b/src/views/home/home.hooks.ts
@@ -2,7 +2,7 @@ import { CollectionPreviewCardData } from '@/components/CollectionPreviewCard';
 import { ProfilePreviewData } from '@/components/ProfilePreviewCard';
 import { QueryContext } from '@/hooks/useApolloQuery';
 import { IndexerSDK, Listing } from '@/modules/indexer';
-import { PublicKey } from '@solana/web3.js';
+import { LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
 import { HomeData } from 'src/pages';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -148,7 +148,7 @@ function transformCollectionPreview(data: CollectionPreviewFragment): Collection
     imageUrl: data.nft.image,
     name: data.nft.name,
     nftCount: data.nftCount ?? 0,
-    floorPriceSol: data.floorPrice ?? 0,
+    floorPriceSol: (data.floorPrice ?? 0) / LAMPORTS_PER_SOL,
   };
 }
 


### PR DESCRIPTION
This PR converts the lamports returned for floor price by the indexer into SOL. It also refactors the collection preview stats to account for the smaller preview cards

![image](https://user-images.githubusercontent.com/1540936/182220670-c6bcb4c9-a257-41ae-b23a-34cef09baa3a.png)
