### PR TITLE
Discover Card Grid Adjustments

### DIFF
--- a/src/components/ProfilePreviewCard.tsx
+++ b/src/components/ProfilePreviewCard.tsx
@@ -60,7 +60,7 @@ export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element 
           />
         </Link>
         {/* preview image */}
-        <div className="relative h-32  flex-shrink-0 overflow-clip">
+        <div className="relative h-32 flex-shrink-0 overflow-clip">
           <img
             src={props.context.data.bannerImageUrl ?? getFallbackImage()}
             alt={`${props.context.data.address} banner`}
@@ -74,7 +74,7 @@ export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element 
           />
         </div>
 
-        <div className="flex h-full w-full flex-col  p-4">
+        <div className="flex h-full w-full flex-col p-4">
           {/* pfp, follow */}
           <div className="relative -mt-12 flex items-end justify-between">
             <div className="h-16 w-16 md:h-12 md:w-12 lg:h-24 lg:w-24">
@@ -111,8 +111,18 @@ export default function ProfilePreview(props: ProfilePreviewProps): JSX.Element 
 
 export function ProfilePreviewLoadingCard(): JSX.Element {
   return (
-    <PreviewContainer>
-      <div className="h-full w-full animate-pulse bg-gray-800" />
+    <PreviewContainer className="animate-pulse">
+      <div className="relative h-32 w-full flex-shrink-0">
+        <div className="absolute top-0 right-0 bottom-0 left-0 z-10 bg-gray-700" />
+      </div>
+      <div className="p-4">
+        <div className="relative z-20 -mt-12 h-16 w-16 rounded-full bg-gray-800 md:h-12 md:w-12 lg:h-24 lg:w-24" />
+        <div className="mt-6 h-6 w-24 rounded-md bg-gray-700 lg:h-8" />
+        <div className="mt-4 flex gap-4">
+          <div className="h-6 w-20 rounded-md bg-gray-700" />
+          <div className="h-6 w-20 rounded-md bg-gray-700" />
+        </div>
+      </div>
     </PreviewContainer>
   );
 }
@@ -121,7 +131,7 @@ const PreviewContainer: FC<any> = ({ className, ...props }) => {
   return (
     <div
       className={clsx(
-        'relative flex w-full overflow-clip rounded-lg bg-gray-900 shadow-md shadow-black duration-300 hover:scale-[1.02]',
+        'relative flex w-full flex-col overflow-clip rounded-lg bg-gray-900 shadow-md shadow-black duration-300 hover:scale-[1.02]',
         className
       )}
       {...props}

--- a/src/hooks/useApolloQuery.ts
+++ b/src/hooks/useApolloQuery.ts
@@ -4,7 +4,7 @@ import {
   QueryHookOptions,
   QueryResult,
 } from '@apollo/client';
-import { useCallback, useMemo, useReducer, useState } from 'react';
+import { useCallback, useMemo, useReducer, useState, Dispatch, SetStateAction } from 'react';
 
 export interface QueryContext<TData, TArgs = void, TGraphQLData = void> {
   data: TData | undefined;
@@ -15,7 +15,11 @@ export interface QueryContext<TData, TArgs = void, TGraphQLData = void> {
 }
 
 export interface UpdateResultsFunction<TGraphQLData> {
-  (prev: TGraphQLData, more: TGraphQLData | null | undefined): TGraphQLData;
+  (
+    prev: TGraphQLData,
+    more: TGraphQLData | null | undefined,
+    setHasMore?: Dispatch<SetStateAction<boolean>>
+  ): TGraphQLData;
 }
 
 interface FetchMoreArgs<TArgs, TGraphQLData = void> {
@@ -69,7 +73,6 @@ export function useHolaplexInfiniteScrollQuery<
   const onCompleted: (raw: TGraphQLDataObject) => void = useCallback(
     (raw) => {
       const rawDataArray: TGraphQLElement[] | undefined = listExtractor(raw);
-      setHasMore(rawDataArray != null && rawDataArray.length > 0);
       if (rawDataArray !== undefined) setData(rawDataArray.map((e) => transformer(e, raw)));
     },
     [listExtractor, transformer, setData]
@@ -98,7 +101,7 @@ export function useHolaplexInfiniteScrollQuery<
           offset: fetchMoreOffset,
         },
         updateQuery: (p, { fetchMoreResult }) => {
-          return mergeResultsFunction(p, fetchMoreResult);
+          return mergeResultsFunction(p, fetchMoreResult, setHasMore);
         },
       });
     }

--- a/src/pages/discover/collections.tsx
+++ b/src/pages/discover/collections.tsx
@@ -17,7 +17,7 @@ import { Select, SelectOption } from '@/components/Select';
 
 const SEARCH_DEBOUNCE_TIMEOUT_MS: number = 500;
 const INITIAL_FETCH: number = 24;
-const INFINITE_SCROLL_AMOUNT_INCREMENT = 24;
+const INFINITE_SCROLL_AMOUNT_INCREMENT = 12;
 
 // values are what appears in the URL
 enum UrlParamKey {

--- a/src/pages/discover/profiles.tsx
+++ b/src/pages/discover/profiles.tsx
@@ -13,8 +13,8 @@ import { DiscoverPageProps, DiscoverLayout } from '@/views/discover/DiscoverLayo
 import { useUrlQueryParam } from '@/hooks/useUrlQueryParam';
 
 const SEARCH_DEBOUNCE_TIMEOUT_MS: number = 500;
-const INITIAL_FETCH: number = 30;
-const INFINITE_SCROLL_AMOUNT_INCREMENT = 6;
+const INITIAL_FETCH: number = 36;
+const INFINITE_SCROLL_AMOUNT_INCREMENT = 24;
 
 enum TypeOption {
   ALL = 'all',

--- a/src/views/discover/discover.hooks.ts
+++ b/src/views/discover/discover.hooks.ts
@@ -128,8 +128,17 @@ export function useDiscoverCollectionsByMarketcapQueryWithTransforms(
   fetchMoreLimit: number
 ): DiscoverCollectionsQueryContext {
   const mergeResultsFunction: UpdateResultsFunction<DiscoverCollectionsByMarketCapQuery> =
-    useCallback((previous, more) => {
+    useCallback((previous, more, setHasMore) => {
       if (!more) return previous;
+
+      if (setHasMore) {
+        if (more.collectionsFeaturedByMarketCap.length === 0) {
+          setHasMore(false);
+        } else {
+          setHasMore(true);
+        }
+      }
+
       more.collectionsFeaturedByMarketCap = [
         ...previous.collectionsFeaturedByMarketCap,
         ...more.collectionsFeaturedByMarketCap,
@@ -161,12 +170,22 @@ export function useDiscoverCollectionsByVolumeLazyQueryWithTransforms(
   fetchMoreLimit: number
 ): DiscoverCollectionsQueryContext {
   const mergeResultsFunction: UpdateResultsFunction<DiscoverCollectionsByVolumeQuery> = useCallback(
-    (previous, more) => {
+    (previous, more, setHasMore) => {
       if (!more) return previous;
+
+      if (setHasMore) {
+        if (more.collectionsFeaturedByVolume.length === 0) {
+          setHasMore(false);
+        } else {
+          setHasMore(true);
+        }
+      }
+
       more.collectionsFeaturedByVolume = [
         ...previous.collectionsFeaturedByVolume,
         ...more.collectionsFeaturedByVolume,
       ];
+
       return { ...more };
     },
     []
@@ -214,8 +233,17 @@ function useDiscoverCollectionsQuery(
   fetchMoreLimit: number
 ): DiscoverCollectionsQueryContext {
   const mergeResultsFunction: UpdateResultsFunction<DiscoverCollectionsByMarketCapQuery> =
-    useCallback((previous, more) => {
+    useCallback((previous, more, setHasMore) => {
       if (!more) return previous;
+
+      if (setHasMore) {
+        if (more.collectionsFeaturedByMarketCap.length === 0) {
+          setHasMore(false);
+        } else {
+          setHasMore(true);
+        }
+      }
+
       more.collectionsFeaturedByMarketCap = [
         ...previous.collectionsFeaturedByMarketCap,
         ...more.collectionsFeaturedByMarketCap,
@@ -266,9 +294,19 @@ export function useDiscoverProfilesAllLazyQueryWithTransforms(
   fetchMoreLimit: number
 ): DiscoverProfilesQueryContext {
   const mergeResultsFunction: UpdateResultsFunction<DiscoverProfilesAllQuery> = useCallback(
-    (previous, more) => {
+    (previous, more, setHasMore) => {
       if (!more) return previous;
+
+      if (setHasMore) {
+        if (more.followWallets.length === 0) {
+          setHasMore(false);
+        } else {
+          setHasMore(true);
+        }
+      }
+
       more.followWallets = [...previous.followWallets, ...more.followWallets];
+
       return { ...more };
     },
     []


### PR DESCRIPTION
### Changes
- Add preview state for profiles
- Instead of has more spinner show a row of preview cards
- Stop show the "no data" fallback text for a moment while the page is initializing
- Dismiss the has more when no more results returned from the api

<img width="1425" alt="Screen Shot 2022-08-04 at 3 08 46 PM" src="https://user-images.githubusercontent.com/2388118/182862939-5e13b9c9-4706-4784-b587-c38d41012ab8.png">
<img width="1456" alt="Screen Shot 2022-08-04 at 3 13 40 PM" src="https://user-images.githubusercontent.com/2388118/182862951-f7a9c3ac-ee40-4d5d-aa3e-daf14ce915f6.png">
<img width="1468" alt="Screen Shot 2022-08-04 at 3 14 43 PM" src="https://user-images.githubusercontent.com/2388118/182862961-b1c41e8c-c1a4-4264-a4cb-166ab7e5b0ec.png">
<img width="1460" alt="Screen Shot 2022-08-04 at 3 14 48 PM" src="https://user-images.githubusercontent.com/2388118/182862967-d871d9ab-b675-45f8-820b-f4a3d77dc64b.png">
<img width="1465" alt="Screen Shot 2022-08-04 at 3 14 54 PM" src="https://user-images.githubusercontent.com/2388118/182862971-293904d5-5c66-42e2-9d22-25530df41ff0.png">
