### PR TITLE
[Fix] Top Volume and Marketcap based on start of each day

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,8 +48,8 @@ export default function Home(): JSX.Element {
 
   const timeIntervales = useMemo(() => {
     const now = DateTime.now();
-    const dayAgo = now.minus({ days: 1 });
-    const nowUTC = now.toUTC().toString();
+    const dayAgo = now.minus({ days: 1 }).startOf('day');
+    const nowUTC = now.startOf('day').toUTC().toString();
     const dayAgoUTC = dayAgo.toUTC().toString();
 
     return { startDate: dayAgoUTC, endDate: nowUTC };


### PR DESCRIPTION
### Changes
- For the top vol and marketcap always do the query based on the top of today and the previous day.

<img width="1454" alt="Screen Shot 2022-08-30 at 6 48 11 PM" src="https://user-images.githubusercontent.com/2388118/187494106-4efde380-4b1e-45fb-9660-dba83e5e77f7.png">
